### PR TITLE
Dashboard: celebrate completing all exercises in the rolling month window

### DIFF
--- a/app/components/DailySuggestions.tsx
+++ b/app/components/DailySuggestions.tsx
@@ -10,14 +10,13 @@ type DailySuggestionsProps = {
 }
 
 export async function DailySuggestions({ userId, preloaded }: DailySuggestionsProps) {
-  const { suggestedExercises, completedExercises, fullLibraryCompleteInRollingWindow } =
+  const { suggestedExercises, completedExercises } =
     preloaded ?? (await getDashboardDailySuggestionsPayload(userId))
 
   return (
     <DailySuggestionsClient
       initialSuggestedExercises={suggestedExercises}
       completedExercises={completedExercises}
-      fullLibraryCompleteInRollingWindow={fullLibraryCompleteInRollingWindow}
     />
   )
-}
+} 

--- a/app/components/DailySuggestions.tsx
+++ b/app/components/DailySuggestions.tsx
@@ -1,29 +1,23 @@
-import { prisma } from '@/lib/prisma'
 import { DailySuggestionsClient } from './DailySuggestionsClient'
-import { getSuggestedExercises } from '@/lib/sessions/suggestions'
+import {
+  getDashboardDailySuggestionsPayload,
+  type DashboardDailySuggestionsPayload,
+} from '@/lib/sessions/suggestions'
 
-export async function DailySuggestions({ userId }: { userId: string }) {
-  const suggestedExercises = await getSuggestedExercises(userId)
-  
-  // Get exercises completed today (from midnight to now)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const completedExercises = await prisma.exerciseCompletion.findMany({
-    where: {
-      userId,
-      createdAt: {
-        gte: today,
-      },
-    },
-    include: {
-      exercise: true,
-    },
-  })
+type DailySuggestionsProps = {
+  userId: string
+  preloaded?: DashboardDailySuggestionsPayload
+}
+
+export async function DailySuggestions({ userId, preloaded }: DailySuggestionsProps) {
+  const { suggestedExercises, completedExercises, fullLibraryCompleteInRollingWindow } =
+    preloaded ?? (await getDashboardDailySuggestionsPayload(userId))
 
   return (
     <DailySuggestionsClient
       initialSuggestedExercises={suggestedExercises}
       completedExercises={completedExercises}
+      fullLibraryCompleteInRollingWindow={fullLibraryCompleteInRollingWindow}
     />
   )
-} 
+}

--- a/app/components/DailySuggestionsClient.tsx
+++ b/app/components/DailySuggestionsClient.tsx
@@ -12,6 +12,8 @@ interface DailySuggestionsClientProps {
     createdAt: Date
     exercise: Exercise
   }[]
+  /** True when every catalog exercise has a completion in the rolling month window. */
+  fullLibraryCompleteInRollingWindow?: boolean
 }
 
 /**
@@ -30,6 +32,7 @@ interface DailySuggestionsClientProps {
 export function DailySuggestionsClient({
   initialSuggestedExercises,
   completedExercises,
+  fullLibraryCompleteInRollingWindow = false,
 }: DailySuggestionsClientProps) {
   const [todaysSuggestedExercises, setTodaysSuggestedExercises] = useState(initialSuggestedExercises)
   const [allExercisesCompleted, setAllExercisesCompleted] = useState(false)
@@ -92,9 +95,22 @@ export function DailySuggestionsClient({
     return acc
   }, {} as Record<string, typeof completedExercises>)
 
+  const hasSuggestionRows = Object.keys(exercisesByCategory).length > 0
+
   return (
     <div className="mb-12">
       <h2 className="text-2xl font-bold text-slate-900 mb-6">Daily Suggestions</h2>
+      {fullLibraryCompleteInRollingWindow && !hasSuggestionRows && (
+        <div className="mb-6 rounded-xl border border-emerald-200/90 bg-emerald-50/90 p-5 text-emerald-950 shadow-sm">
+          <p className="font-medium">
+            You are fully caught up for this cycle—there is nothing new to assign
+            here until your rolling window advances.
+          </p>
+          <p className="mt-2 text-sm text-emerald-900/90">
+            You can still revisit any exercise from Conditioning or Restorative below.
+          </p>
+        </div>
+      )}
       {allExercisesCompleted && (
         <div className="mb-6 p-4 rounded-lg border border-green-200 bg-green-50 text-green-700">
           Congratulations! You have completed all exercises for today!

--- a/app/components/DailySuggestionsClient.tsx
+++ b/app/components/DailySuggestionsClient.tsx
@@ -12,8 +12,6 @@ interface DailySuggestionsClientProps {
     createdAt: Date
     exercise: Exercise
   }[]
-  /** True when every catalog exercise has a completion in the rolling month window. */
-  fullLibraryCompleteInRollingWindow?: boolean
 }
 
 /**
@@ -32,7 +30,6 @@ interface DailySuggestionsClientProps {
 export function DailySuggestionsClient({
   initialSuggestedExercises,
   completedExercises,
-  fullLibraryCompleteInRollingWindow = false,
 }: DailySuggestionsClientProps) {
   const [todaysSuggestedExercises, setTodaysSuggestedExercises] = useState(initialSuggestedExercises)
   const [allExercisesCompleted, setAllExercisesCompleted] = useState(false)
@@ -95,22 +92,9 @@ export function DailySuggestionsClient({
     return acc
   }, {} as Record<string, typeof completedExercises>)
 
-  const hasSuggestionRows = Object.keys(exercisesByCategory).length > 0
-
   return (
     <div className="mb-12">
       <h2 className="text-2xl font-bold text-slate-900 mb-6">Daily Suggestions</h2>
-      {fullLibraryCompleteInRollingWindow && !hasSuggestionRows && (
-        <div className="mb-6 rounded-xl border border-emerald-200/90 bg-emerald-50/90 p-5 text-emerald-950 shadow-sm">
-          <p className="font-medium">
-            You are fully caught up for this cycle—there is nothing new to assign
-            here until your rolling window advances.
-          </p>
-          <p className="mt-2 text-sm text-emerald-900/90">
-            You can still revisit any exercise from Conditioning or Restorative below.
-          </p>
-        </div>
-      )}
       {allExercisesCompleted && (
         <div className="mb-6 p-4 rounded-lg border border-green-200 bg-green-50 text-green-700">
           Congratulations! You have completed all exercises for today!

--- a/app/components/MonthCompletionCelebration.tsx
+++ b/app/components/MonthCompletionCelebration.tsx
@@ -1,0 +1,41 @@
+/**
+ * Prominent celebratory callout when the subscriber has logged at least one
+ * completion within the rolling month window for every exercise in the catalog.
+ */
+export function MonthCompletionCelebration() {
+  return (
+    <div
+      className="relative mb-10 overflow-hidden rounded-2xl border border-amber-200/90 bg-gradient-to-br from-amber-50 via-orange-50 to-rose-50 p-8 shadow-lg ring-1 ring-amber-100/80"
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className="pointer-events-none absolute -right-8 -top-8 h-40 w-40 rounded-full bg-amber-200/40 blur-2xl"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -bottom-10 -left-10 h-36 w-36 rounded-full bg-rose-200/35 blur-2xl"
+        aria-hidden
+      />
+
+      <div className="relative">
+        <p className="text-sm font-semibold uppercase tracking-wide text-amber-800/90">
+          Milestone
+        </p>
+        <h2 className="mt-2 text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+          <span className="mr-2 inline-block" aria-hidden>
+            🎉
+          </span>
+          Congratulations!
+        </h2>
+        <p className="mt-4 max-w-2xl text-lg leading-relaxed text-slate-800">
+          You have completed all of your exercises this month—every movement in
+          your Mobility Blueprint has a fresh completion in your rolling window.
+        </p>
+        <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed text-slate-700">
+          Go out and move your body in any way that feels good to you.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,9 @@ import { redirect } from "next/navigation"
 import Link from "next/link"
 import { authConfig } from "@/lib/auth"
 import { DailySuggestions } from "../components/DailySuggestions"
+import { MonthCompletionCelebration } from "../components/MonthCompletionCelebration"
 import { prisma } from "@/lib/prisma"
+import { getDashboardDailySuggestionsPayload } from "@/lib/sessions/suggestions"
 
 /**
  * Categories of exercises available in the app.
@@ -58,6 +60,8 @@ export default async function Dashboard() {
     redirect('/subscribe')
   }
 
+  const suggestionsPayload = await getDashboardDailySuggestionsPayload(user.id)
+
   return (
     <div className="min-h-screen bg-slate-100 py-12">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -68,7 +72,11 @@ export default async function Dashboard() {
           </p>
         </div>
 
-        <DailySuggestions userId={user.id} />
+        {suggestionsPayload.fullLibraryCompleteInRollingWindow && (
+          <MonthCompletionCelebration />
+        )}
+
+        <DailySuggestions userId={user.id} preloaded={suggestionsPayload} />
 
         <Link
           href="/sessions"
@@ -101,4 +109,4 @@ export default async function Dashboard() {
       </div>
     </div>
   )
-} 
+}

--- a/lib/sessions/suggestions.ts
+++ b/lib/sessions/suggestions.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma'
+import type { ExerciseCompletion, Exercise as PrismaExercise } from '@prisma/client'
 
 interface SuggestedExercise {
   id: string
@@ -9,11 +10,23 @@ interface SuggestedExercise {
   subCategory: string | null
 }
 
+export type DashboardCompletionWithExercise = ExerciseCompletion & {
+  exercise: PrismaExercise
+}
+
+export type DashboardDailySuggestionsPayload = {
+  suggestedExercises: SuggestedExercise[]
+  completedExercises: DashboardCompletionWithExercise[]
+  /** Every catalog exercise has a completion within the rolling month window (matches suggestions SQL). */
+  fullLibraryCompleteInRollingWindow: boolean
+}
+
 /**
  * Returns one random un-completed exercise per category/subcategory group
  * for the given user, excluding anything completed in the last month.
  *
- * This is the same query used by the DailySuggestions server component.
+ * This is the same query used by the DailySuggestions server component,
+ * extracted here so it can be reused by the group-session intersection logic.
  */
 export async function getSuggestedExercises(userId: string): Promise<SuggestedExercise[]> {
   return prisma.$queryRaw<SuggestedExercise[]>`
@@ -47,9 +60,8 @@ export async function getSuggestedExercises(userId: string): Promise<SuggestedEx
 }
 
 /**
- * All exercises the user is eligible for (not completed in the last month),
- * in random order. Used for group plan generation so the leader algorithm can
- * intersect full participant pools and pick per subcategory.
+ * Returns all exercises the user is eligible for today (not completed
+ * in the last month), in random order.
  */
 export async function getEligibleExercises(userId: string): Promise<SuggestedExercise[]> {
   return prisma.$queryRaw<SuggestedExercise[]>`
@@ -70,4 +82,38 @@ export async function getEligibleExercises(userId: string): Promise<SuggestedExe
     )
     ORDER BY random();
   `
+}
+
+/**
+ * Loads dashboard daily-suggestion data in one round trip where possible.
+ * `fullLibraryCompleteInRollingWindow` is true when the user has a completion
+ * dated within the rolling one-month window for every exercise in the catalog
+ * (same rule as category pages and `/api/exercises/complete`).
+ */
+export async function getDashboardDailySuggestionsPayload(
+  userId: string
+): Promise<DashboardDailySuggestionsPayload> {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const [suggestedExercises, totalExercises, completedExercises] = await Promise.all([
+    getSuggestedExercises(userId),
+    prisma.exercise.count(),
+    prisma.exerciseCompletion.findMany({
+      where: {
+        userId,
+        createdAt: { gte: today },
+      },
+      include: { exercise: true },
+    }),
+  ])
+
+  const fullLibraryCompleteInRollingWindow =
+    totalExercises > 0 && suggestedExercises.length === 0
+
+  return {
+    suggestedExercises,
+    completedExercises,
+    fullLibraryCompleteInRollingWindow,
+  }
 }


### PR DESCRIPTION
## Summary

Shows a celebratory banner on `/dashboard` when the subscriber has at least one completion within the same **rolling one-month** window used everywhere else (`NOW() - INTERVAL '1 month'`) for **every** exercise in the catalog (i.e. `getSuggestedExercises` returns no rows and the exercise table is non-empty).

## Changes

- New `MonthCompletionCelebration` component (gradient card, milestone copy, encouragement to move freely).
- `getDashboardDailySuggestionsPayload` in `lib/sessions/suggestions.ts` loads suggestions and today’s completions in parallel and derives `fullLibraryCompleteInRollingWindow` without duplicating the suggestions query from the dashboard.
- `DailySuggestions` accepts optional `preloaded` payload from the dashboard.
- `DailySuggestionsClient`: when the library is fully complete and there are no suggestion rows, shows a short “caught up for this cycle” note.

## Testing

- [ ] Vercel preview: dashboard as a user who has completed every exercise in the rolling window.
- [ ] Partial progress: no banner.

## Note

“Month” matches existing app semantics (rolling `1 month` in SQL), not a fixed 30-day calendar month.