### PR TITLE
Prioritize longest-overdue exercises in daily suggestions

### DIFF
--- a/lib/sessions/suggestions.ts
+++ b/lib/sessions/suggestions.ts
@@ -22,36 +22,44 @@ export type DashboardDailySuggestionsPayload = {
 }
 
 /**
- * Returns one random un-completed exercise per category/subcategory group
- * for the given user, excluding anything completed in the last month.
+ * Returns one un-completed exercise per category/subcategory group for the
+ * given user, excluding anything completed in the last month. Within each
+ * group, exercises that have gone longest without being completed are
+ * prioritized (never-completed exercises rank above ones the user is merely
+ * eligible for again after the cooldown), with a random tiebreak among
+ * exercises that are equally overdue (e.g. multiple never-completed in the
+ * same group).
  *
  * This is the same query used by the DailySuggestions server component,
  * extracted here so it can be reused by the group-session intersection logic.
  */
 export async function getSuggestedExercises(userId: string): Promise<SuggestedExercise[]> {
   return prisma.$queryRaw<SuggestedExercise[]>`
-    WITH RankedExercises AS (
-      SELECT 
+    WITH LastCompletion AS (
+      SELECT ec."exerciseId", MAX(ec."createdAt") AS last_completed_at
+      FROM exercise_completions ec
+      WHERE ec."userId" = ${userId}
+      GROUP BY ec."exerciseId"
+    ),
+    RankedExercises AS (
+      SELECT
         e.*,
+        lc.last_completed_at,
         ROW_NUMBER() OVER (
           PARTITION BY e.category, e."subCategory"
-          ORDER BY (SELECT random())
+          ORDER BY lc.last_completed_at ASC NULLS FIRST, random()
         ) as rn
       FROM exercises e
-      WHERE NOT EXISTS (
-        SELECT 1 
-        FROM exercise_completions ec 
-        WHERE e.id = ec."exerciseId" 
-        AND ec."userId" = ${userId}
-        AND ec."createdAt" >= NOW() - INTERVAL '1 month'
-      )
+      LEFT JOIN LastCompletion lc ON lc."exerciseId" = e.id
+      WHERE lc.last_completed_at IS NULL
+        OR lc.last_completed_at < NOW() - INTERVAL '1 month'
     )
-    SELECT 
-      id, 
-      name, 
-      description, 
-      "imageUrl", 
-      category, 
+    SELECT
+      id,
+      name,
+      description,
+      "imageUrl",
+      category,
       "subCategory"
     FROM RankedExercises
     WHERE rn = 1


### PR DESCRIPTION
## Summary
- `getSuggestedExercises` previously picked randomly among all exercises outside the 1-month cooldown, so an exercise a user just became re-eligible for and one they hadn't touched in months had equal odds of being suggested.
- Now ranks each category/subcategory group by last completion date (never-completed first, then oldest last-completed), only falling back to a random tiebreak among true ties (e.g. multiple never-completed exercises in the same group).
- `getEligibleExercises` (used for group-plan pooling) is intentionally left as-is — its random order is used for fairness when intersecting multiple participants' eligible pools, which is a different concern.

## Test plan
- [x] `npx tsc --noEmit` — no new type errors introduced (two pre-existing unrelated errors in `Author.tsx`/`Hero.tsx`)
- [x] Ran the new query live against the dev DB for a real user with a mix of completion ages: confirmed exercises completed within the last month are correctly excluded, and the exercise with the oldest last-completed timestamp in each category/subcategory group is the one returned (e.g. an exercise last done ~7 months ago surfaced over one merely past the 30-day cooldown)
- [ ] Manual check in the running app dashboard (not yet done — recommend a quick look before merge)

https://claude.ai/code/session_01Ekg19WNc8iS4gTxmymq1yV