### PR TITLE
feat(dashboard): redesign daily suggestions as a vertical timeline

### DIFF
--- a/app/components/DailySuggestionsClient.tsx
+++ b/app/components/DailySuggestionsClient.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { CheckIcon } from '@heroicons/react/20/solid'
+import { FlagIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 import { ExerciseDetailModal } from './ExerciseDetailModal'
 import { getExerciseVisual } from './exerciseVisuals'
@@ -14,6 +15,24 @@ interface DailySuggestionsClientProps {
     createdAt: Date
     exercise: Exercise
   }[]
+}
+
+// Conditioning is shown before Restorative to match the order used
+// elsewhere in the app (e.g. the dashboard's category browse cards).
+// Any other category value falls back to the order it's first seen in.
+const CATEGORY_ORDER = ['conditioning', 'restorative']
+
+function groupExercisesByCategory(exercises: Exercise[]) {
+  const seenCategories = Array.from(new Set(exercises.map((exercise) => exercise.category)))
+  const orderedCategories = [
+    ...CATEGORY_ORDER.filter((category) => seenCategories.includes(category)),
+    ...seenCategories.filter((category) => !CATEGORY_ORDER.includes(category)),
+  ]
+
+  return orderedCategories.map((category) => ({
+    category,
+    exercises: exercises.filter((exercise) => exercise.category === category),
+  }))
 }
 
 /**
@@ -63,64 +82,92 @@ export function DailySuggestionsClient({
       )}
       <div className="mx-auto max-w-xl rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
         <ol className="relative">
-          {initialSuggestedExercises.map((exercise, index) => {
-            const isDone = completedIds.has(exercise.id)
-            const visual = getExerciseVisual(exercise.category, exercise.subCategory)
-            const Icon = visual.icon
-            const isLast = index === initialSuggestedExercises.length - 1
+          {groupExercisesByCategory(initialSuggestedExercises).map((group, groupIndex, groups) => {
+            const sectionVisual = getExerciseVisual(group.category, null)
+            const isLastGroup = groupIndex === groups.length - 1
 
             return (
-              <li key={exercise.id} className="relative pb-8 last:pb-0">
-                {!isLast && (
+              <Fragment key={group.category}>
+                <li className="relative pb-4">
                   <span
                     className="absolute left-5 top-5 -ml-px h-full w-0.5 bg-slate-200"
                     aria-hidden="true"
                   />
-                )}
-                <button
-                  type="button"
-                  onClick={() => openExercise(exercise)}
-                  className="group relative flex w-full items-start gap-4 text-left"
-                >
-                  <span
-                    className={clsx(
-                      'relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ring-4 ring-white',
-                      isDone ? 'bg-emerald-500' : visual.badgeClass
-                    )}
-                  >
-                    {isDone ? (
-                      <CheckIcon className="h-5 w-5 text-white" />
-                    ) : (
-                      <Icon className="h-5 w-5 text-white" />
-                    )}
-                  </span>
-                  <span
-                    className={clsx(
-                      'flex min-w-0 flex-1 flex-col gap-1 rounded-lg border p-3 transition-colors',
-                      isDone
-                        ? 'border-emerald-100 bg-emerald-50/60'
-                        : 'border-slate-200 bg-white group-hover:border-slate-300 group-hover:shadow-sm'
-                    )}
-                  >
+                  <div className="relative flex items-center gap-4">
                     <span
                       className={clsx(
-                        'text-base font-semibold normal-case',
-                        isDone ? 'text-slate-500' : 'text-slate-900'
+                        'relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ring-4 ring-white',
+                        sectionVisual.badgeClass
                       )}
                     >
-                      {exercise.name}
+                      <FlagIcon className="h-5 w-5 text-white" />
                     </span>
-                    <span
-                      className={clsx(
-                        'inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
-                        visual.tagClass
+                    <span className="text-sm font-bold uppercase tracking-wide text-slate-500">
+                      {sectionVisual.label}
+                    </span>
+                  </div>
+                </li>
+                {group.exercises.map((exercise, index) => {
+                  const isDone = completedIds.has(exercise.id)
+                  const visual = getExerciseVisual(exercise.category, exercise.subCategory)
+                  const Icon = visual.icon
+                  const isVeryLastExercise = isLastGroup && index === group.exercises.length - 1
+
+                  return (
+                    <li key={exercise.id} className="relative pb-8 last:pb-0">
+                      {!isVeryLastExercise && (
+                        <span
+                          className="absolute left-5 top-5 -ml-px h-full w-0.5 bg-slate-200"
+                          aria-hidden="true"
+                        />
                       )}
-                    >
-                      {visual.label}
-                    </span>
-                  </span>
-                </button>
-              </li>
+                      <button
+                        type="button"
+                        onClick={() => openExercise(exercise)}
+                        className="group relative flex w-full items-start gap-4 text-left"
+                      >
+                        <span
+                          className={clsx(
+                            'relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ring-4 ring-white',
+                            isDone ? 'bg-emerald-500' : visual.badgeClass
+                          )}
+                        >
+                          {isDone ? (
+                            <CheckIcon className="h-5 w-5 text-white" />
+                          ) : (
+                            <Icon className="h-5 w-5 text-white" />
+                          )}
+                        </span>
+                        <span
+                          className={clsx(
+                            'flex min-w-0 flex-1 flex-col gap-1 rounded-lg border p-3 transition-colors',
+                            isDone
+                              ? 'border-emerald-100 bg-emerald-50/60'
+                              : 'border-slate-200 bg-white group-hover:border-slate-300 group-hover:shadow-sm'
+                          )}
+                        >
+                          <span
+                            className={clsx(
+                              'text-base font-semibold normal-case',
+                              isDone ? 'text-slate-500' : 'text-slate-900'
+                            )}
+                          >
+                            {exercise.name}
+                          </span>
+                          <span
+                            className={clsx(
+                              'inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                              visual.tagClass
+                            )}
+                          >
+                            {visual.label}
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                  )
+                })}
+              </Fragment>
             )
           })}
         </ol>

--- a/app/components/DailySuggestionsClient.tsx
+++ b/app/components/DailySuggestionsClient.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { useState } from 'react'
-import Image from 'next/image'
-import { CompleteExerciseButton } from './CompleteExerciseButton'
+import { CheckIcon } from '@heroicons/react/20/solid'
+import clsx from 'clsx'
+import { ExerciseDetailModal } from './ExerciseDetailModal'
+import { getExerciseVisual } from './exerciseVisuals'
 import { Exercise } from '@/app/types/exercise'
 
 interface DailySuggestionsClientProps {
@@ -15,179 +17,123 @@ interface DailySuggestionsClientProps {
 }
 
 /**
- * Client-side component that displays suggested and completed exercises.
- * 
- * This component:
- * 1. Shows suggested exercises grouped by category
- * 2. Tracks exercise completion state
- * 3. Shows a success message when all exercises are completed
- * 4. Displays completed exercises in a separate section
- * 5. Handles exercise completion through CompleteExerciseButton
- *
- * @param initialSuggestedExercises - Array of exercises suggested for the day
- * @param completedExercises - Array of exercises completed today
+ * Client-side component that renders the day's suggested exercises as a
+ * vertical timeline. Items stay in their suggested order and switch to a
+ * checked visual state on completion rather than being removed or moved to
+ * a separate section. Tapping an item opens the full detail view.
  */
 export function DailySuggestionsClient({
   initialSuggestedExercises,
   completedExercises,
 }: DailySuggestionsClientProps) {
-  const [todaysSuggestedExercises, setTodaysSuggestedExercises] = useState(initialSuggestedExercises)
-  const [allExercisesCompleted, setAllExercisesCompleted] = useState(false)
-
-  const completedExerciseIds = new Set(
-    completedExercises.map(completion => completion.exercise.id)
+  const [completedIds, setCompletedIds] = useState<Set<string>>(
+    () => new Set(completedExercises.map((c) => c.exercise.id))
   )
+  const [completedAtById, setCompletedAtById] = useState<Record<string, Date>>(
+    () => Object.fromEntries(completedExercises.map((c) => [c.exercise.id, c.createdAt]))
+  )
+  const [selectedExercise, setSelectedExercise] = useState<Exercise | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
-  /**
-   * Handles completion of an exercise by removing it from suggested exercises.
-   * 
-   * This function:
-   * 1. Filters out the completed exercise from the suggested exercises list
-   * 2. If no exercises remain, sets allExercisesCompleted flag to true
-   * 3. Returns the updated list of suggested exercises
-   * 
-   * @param exerciseId - ID of the exercise that was completed
-   */
-  const handleExerciseComplete = (exerciseId: string) => {
-    setTodaysSuggestedExercises(prev => {
-      const updatedExercises = prev.filter(exercise => exercise.id !== exerciseId)
-      if (updatedExercises.length === 0) {
-        setAllExercisesCompleted(true)
-      }
-      return updatedExercises
-    })
+  const allCompleted =
+    initialSuggestedExercises.length > 0 &&
+    initialSuggestedExercises.every((exercise) => completedIds.has(exercise.id))
+
+  const openExercise = (exercise: Exercise) => {
+    setSelectedExercise(exercise)
+    setIsModalOpen(true)
   }
 
-  /**
-   * Groups suggested exercises by their category.
-   * 
-   * This reduces the exercises array into an object where:
-   * - Keys are lowercase category names
-   * - Values are arrays of exercises in that category
-   * Used to organize exercises for display in the UI.
-   */
-  const exercisesByCategory = todaysSuggestedExercises.reduce((acc, exercise) => {
-    const category = exercise.category.toLowerCase()
-    if (!acc[category]) {
-      acc[category] = []
-    }
-    acc[category].push(exercise)
-    return acc
-  }, {} as Record<string, Exercise[]>)
+  const closeModal = () => {
+    setIsModalOpen(false)
+  }
 
-  /**
-   * Groups completed exercises by their category.
-   * 
-   * This reduces the completions array into an object where:
-   * - Keys are lowercase category names
-   * - Values are arrays of exercise completions in that category
-   * Used to track which exercises have been completed in each category.
-   */
-  const completedExercisesByCategory = completedExercises.reduce((acc, completion) => {
-    const category = completion.exercise.category.toLowerCase()
-    if (!acc[category]) {
-      acc[category] = []
-    }
-    acc[category].push(completion)
-    return acc
-  }, {} as Record<string, typeof completedExercises>)
+  const handleExerciseComplete = (exerciseId: string) => {
+    setCompletedIds((prev) => new Set(prev).add(exerciseId))
+    setCompletedAtById((prev) => ({ ...prev, [exerciseId]: new Date() }))
+  }
 
   return (
     <div className="mb-12">
       <h2 className="text-2xl font-bold text-slate-900 mb-6">Daily Suggestions</h2>
-      {allExercisesCompleted && (
+      {allCompleted && (
         <div className="mb-6 p-4 rounded-lg border border-green-200 bg-green-50 text-green-700">
           Congratulations! You have completed all exercises for today!
         </div>
       )}
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-        {Object.entries(exercisesByCategory).map(([category, exercises]) => (
-          <div key={category}>
-            <h3 className="text-xl font-semibold text-slate-800 mb-4 capitalize">
-              {category}
-            </h3>
-            <div className="grid grid-cols-1 gap-4">
-              {exercises.map((exercise) => (
-                <div
-                  key={exercise.id}
-                  className={`flex flex-col sm:flex-row items-start sm:items-center gap-4 p-4 rounded-lg border border-slate-200 bg-white ${
-                    completedExerciseIds.has(exercise.id) ? 'bg-green-50' : ''
-                  }`}
+      <div className="mx-auto max-w-xl rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+        <ol className="relative">
+          {initialSuggestedExercises.map((exercise, index) => {
+            const isDone = completedIds.has(exercise.id)
+            const visual = getExerciseVisual(exercise.category, exercise.subCategory)
+            const Icon = visual.icon
+            const isLast = index === initialSuggestedExercises.length - 1
+
+            return (
+              <li key={exercise.id} className="relative pb-8 last:pb-0">
+                {!isLast && (
+                  <span
+                    className="absolute left-5 top-5 -ml-px h-full w-0.5 bg-slate-200"
+                    aria-hidden="true"
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={() => openExercise(exercise)}
+                  className="group relative flex w-full items-start gap-4 text-left"
                 >
-                  {exercise.imageUrl && (
-                    <div className="relative h-40 w-full sm:h-16 sm:w-16 flex-shrink-0">
-                      <Image
-                        src={exercise.imageUrl}
-                        alt={exercise.name}
-                        fill
-                        className="object-cover rounded-md"
-                      />
-                    </div>
-                  )}
-                  <div className="flex-grow w-full">
-                    <h4 className="font-medium text-slate-900">{exercise.name}</h4>
-                    {exercise.subCategory && (
-                      <p className="text-sm text-slate-600 line-clamp-2">
-                        {exercise.subCategory.replace(/([A-Z])/g, ' $1').toLowerCase().trim()}
-                      </p>
+                  <span
+                    className={clsx(
+                      'relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ring-4 ring-white',
+                      isDone ? 'bg-emerald-500' : visual.badgeClass
                     )}
-                  </div>
-                  <div className="w-full sm:w-[300px]">
-                    <CompleteExerciseButton
-                      exerciseId={exercise.id}
-                      isCompleted={completedExerciseIds.has(exercise.id)}
-                      completedAt={completedExercises.find(c => c.exercise.id === exercise.id)?.createdAt || null}
-                      onComplete={() => handleExerciseComplete(exercise.id)}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-      <h2 className="text-2xl font-bold text-slate-900 mb-6">Completed Exercises</h2>
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-        {Object.entries(completedExercisesByCategory).map(([category, completions]) => (
-          <div key={category}>
-            <h3 className="text-xl font-semibold text-slate-800 mb-4 capitalize">
-              {category}
-            </h3>
-            <div className="grid grid-cols-1 gap-4">
-              {completions.map((completion) => (
-                <div
-                  key={completion.id}
-                  className="flex flex-col sm:flex-row items-start sm:items-center gap-4 p-4 rounded-lg border border-slate-200 bg-green-50"
-                >
-                  {completion.exercise.imageUrl && (
-                    <div className="relative h-40 w-full sm:h-16 sm:w-16 flex-shrink-0">
-                      <Image
-                        src={completion.exercise.imageUrl}
-                        alt={completion.exercise.name}
-                        fill
-                        className="object-cover rounded-md"
-                      />
-                    </div>
-                  )}
-                  <div className="flex-grow">
-                    <h4 className="font-medium text-slate-900">{completion.exercise.name}</h4>
-                    {completion.exercise.subCategory && (
-                      <p className="text-sm text-slate-600 line-clamp-2">
-                        {completion.exercise.subCategory.replace(/([A-Z])/g, ' $1').toLowerCase().trim()}
-                      </p>
+                  >
+                    {isDone ? (
+                      <CheckIcon className="h-5 w-5 text-white" />
+                    ) : (
+                      <Icon className="h-5 w-5 text-white" />
                     )}
-                  </div>
-                  <div className="w-full sm:w-[300px]">
-                    <div className="px-4 py-2 text-center text-green-700 bg-green-100 rounded-md">
-                      Completed
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
+                  </span>
+                  <span
+                    className={clsx(
+                      'flex min-w-0 flex-1 flex-col gap-1 rounded-lg border p-3 transition-colors',
+                      isDone
+                        ? 'border-emerald-100 bg-emerald-50/60'
+                        : 'border-slate-200 bg-white group-hover:border-slate-300 group-hover:shadow-sm'
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        'text-base font-semibold normal-case',
+                        isDone ? 'text-slate-500' : 'text-slate-900'
+                      )}
+                    >
+                      {exercise.name}
+                    </span>
+                    <span
+                      className={clsx(
+                        'inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+                        visual.tagClass
+                      )}
+                    >
+                      {visual.label}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+        </ol>
       </div>
+
+      <ExerciseDetailModal
+        exercise={selectedExercise}
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        isCompleted={selectedExercise ? completedIds.has(selectedExercise.id) : false}
+        completedAt={selectedExercise ? completedAtById[selectedExercise.id] ?? null : null}
+        onComplete={() => selectedExercise && handleExerciseComplete(selectedExercise.id)}
+      />
     </div>
   )
 }

--- a/app/components/ExerciseDetailModal.tsx
+++ b/app/components/ExerciseDetailModal.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
+import { ClockIcon, VideoCameraIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import Image from 'next/image'
+import clsx from 'clsx'
+import { CompleteExerciseButton } from './CompleteExerciseButton'
+import { getExerciseVisual } from './exerciseVisuals'
+import { Exercise } from '@/app/types/exercise'
+
+interface ExerciseDetailModalProps {
+  exercise: Exercise | null
+  isOpen: boolean
+  onClose: () => void
+  isCompleted: boolean
+  completedAt: Date | null
+  onComplete: () => void
+}
+
+export function ExerciseDetailModal({
+  exercise,
+  isOpen,
+  onClose,
+  isCompleted,
+  completedAt,
+  onComplete,
+}: ExerciseDetailModalProps) {
+  if (!exercise) return null
+
+  const visual = getExerciseVisual(exercise.category, exercise.subCategory)
+  const Icon = visual.icon
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} transition className="relative z-50">
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-slate-900/60 duration-200 ease-out data-[closed]:opacity-0"
+      />
+      <div className="fixed inset-0 flex w-screen items-center justify-center sm:p-4">
+        <DialogPanel
+          transition
+          className="flex h-full w-full flex-col overflow-y-auto bg-white duration-200 ease-out data-[closed]:translate-y-4 data-[closed]:opacity-0 sm:h-auto sm:max-h-[90vh] sm:max-w-lg sm:rounded-2xl sm:shadow-xl"
+        >
+          <div className="relative h-56 w-full flex-shrink-0 bg-slate-100 sm:h-64 sm:rounded-t-2xl">
+            {exercise.imageUrl && (
+              <Image
+                src={exercise.imageUrl}
+                alt={exercise.name}
+                fill
+                className="object-cover sm:rounded-t-2xl"
+              />
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="absolute right-4 top-4 rounded-full bg-white/90 p-2 text-slate-700 shadow-sm hover:bg-white"
+            >
+              <XMarkIcon className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="flex-1 px-6 py-6">
+            <span
+              className={clsx(
+                'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium',
+                visual.tagClass
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {visual.label}
+            </span>
+
+            <DialogTitle as="h2" className="normal-case mt-3 text-2xl font-bold text-slate-900">
+              {exercise.name}
+            </DialogTitle>
+
+            {exercise.description && (
+              <p className="mt-3 whitespace-pre-line text-base leading-relaxed text-slate-600">
+                {exercise.description}
+              </p>
+            )}
+
+            <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="flex items-center gap-3 rounded-lg border border-dashed border-slate-200 bg-slate-50 p-4">
+                <ClockIcon className="h-5 w-5 text-slate-400" />
+                <div>
+                  <p className="text-sm font-medium text-slate-700">Timer</p>
+                  <p className="text-xs text-slate-400">Coming soon</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 rounded-lg border border-dashed border-slate-200 bg-slate-50 p-4">
+                <VideoCameraIcon className="h-5 w-5 text-slate-400" />
+                <div>
+                  <p className="text-sm font-medium text-slate-700">Video</p>
+                  <p className="text-xs text-slate-400">Coming soon</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-6">
+              <CompleteExerciseButton
+                exerciseId={exercise.id}
+                isCompleted={isCompleted}
+                completedAt={completedAt}
+                onComplete={onComplete}
+              />
+            </div>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  )
+}

--- a/app/components/exerciseVisuals.ts
+++ b/app/components/exerciseVisuals.ts
@@ -1,0 +1,42 @@
+import type { ComponentType, SVGProps } from 'react'
+import {
+  ArrowsRightLeftIcon,
+  ArrowsPointingInIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  ArrowPathIcon,
+  SparklesIcon,
+  MoonIcon,
+} from '@heroicons/react/24/outline'
+
+export type ExerciseVisual = {
+  icon: ComponentType<SVGProps<SVGSVGElement>>
+  badgeClass: string
+  tagClass: string
+  label: string
+}
+
+const SUBCATEGORY_VISUALS: Record<string, ExerciseVisual> = {
+  lateralLines: { icon: ArrowsRightLeftIcon, badgeClass: 'bg-sky-500', tagClass: 'bg-sky-50 text-sky-700', label: 'Lateral Lines' },
+  innerLines: { icon: ArrowsPointingInIcon, badgeClass: 'bg-violet-500', tagClass: 'bg-violet-50 text-violet-700', label: 'Inner Lines' },
+  frontLine: { icon: ArrowUpIcon, badgeClass: 'bg-amber-500', tagClass: 'bg-amber-50 text-amber-700', label: 'Front Line' },
+  backLine: { icon: ArrowDownIcon, badgeClass: 'bg-rose-500', tagClass: 'bg-rose-50 text-rose-700', label: 'Back Line' },
+  spiralLine: { icon: ArrowPathIcon, badgeClass: 'bg-fuchsia-500', tagClass: 'bg-fuchsia-50 text-fuchsia-700', label: 'Spiral Line' },
+}
+
+const CATEGORY_VISUALS: Record<string, ExerciseVisual> = {
+  conditioning: { icon: SparklesIcon, badgeClass: 'bg-blue-600', tagClass: 'bg-blue-50 text-blue-700', label: 'Conditioning' },
+  restorative: { icon: MoonIcon, badgeClass: 'bg-teal-600', tagClass: 'bg-teal-50 text-teal-700', label: 'Restorative' },
+}
+
+const DEFAULT_VISUAL: ExerciseVisual = {
+  icon: SparklesIcon,
+  badgeClass: 'bg-slate-500',
+  tagClass: 'bg-slate-100 text-slate-700',
+  label: 'Exercise',
+}
+
+export function getExerciseVisual(category: string, subCategory: string | null): ExerciseVisual {
+  if (subCategory && SUBCATEGORY_VISUALS[subCategory]) return SUBCATEGORY_VISUALS[subCategory]
+  return CATEGORY_VISUALS[category] ?? DEFAULT_VISUAL
+}


### PR DESCRIPTION
Replaces the two-category grid + separate completed-section layout with a single Elevate-style vertical timeline so there's room for the upcoming long-form descriptions, timer, and video without cluttering the dashboard. Tapping an item opens a full-screen detail modal with the description and "coming soon" placeholders for timer/video.