### PR TITLE
Add rich text support for exercise descriptions

### DIFF
--- a/app/[category]/[subcategory]/page.tsx
+++ b/app/[category]/[subcategory]/page.tsx
@@ -1,10 +1,15 @@
 import { notFound } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
+import type { Prisma } from '@prisma/client'
 import { getServerSession } from 'next-auth'
 import { authConfig } from '@/lib/auth'
 import Image from 'next/image'
+import { PortableText } from '@portabletext/react'
 import { CompleteExerciseButton } from '@/app/components/CompleteExerciseButton'
+import { createExerciseDescriptionComponents, isPortableTextBlocks } from '@/app/components/exerciseDescription'
 import { redirect } from 'next/navigation'
+
+const descriptionComponents = createExerciseDescriptionComponents('mt-2 text-sm text-slate-600')
 
 // Define valid categories and subcategories based on our schema
 const validCategories = ['conditioning', 'restorative']
@@ -22,7 +27,7 @@ type PageParams = {
 interface ExerciseWithCompletions {
   id: string
   name: string
-  description: string | null
+  description: Prisma.JsonValue | null
   imageUrl: string | null
   isCompleted: boolean
   completedAt: Date | null
@@ -113,8 +118,8 @@ export default async function ExercisesPage({ params }: PageParams) {
               )}
               <div className="p-4">
                 <h3 className="text-lg font-semibold text-slate-800">{exercise.name}</h3>
-                {exercise.description && (
-                  <p className="mt-2 text-sm text-slate-600">{exercise.description}</p>
+                {isPortableTextBlocks(exercise.description) && (
+                  <PortableText value={exercise.description} components={descriptionComponents} />
                 )}
                 <CompleteExerciseButton
                   exerciseId={exercise.id}

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
+import type { Prisma } from '@prisma/client'
 import { authConfig } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 
@@ -48,7 +49,7 @@ export async function GET(
     let exercises: {
       id: string
       name: string
-      description: string | null
+      description: Prisma.JsonValue | null
       imageUrl: string | null
       category: string
       subCategory: string | null

--- a/app/api/sync-exercises/route.ts
+++ b/app/api/sync-exercises/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server'
+import type { PortableTextBlock } from '@portabletext/types'
 import { client } from '@/sanity/lib/client'
 import { prisma } from '@/lib/prisma'
 
 interface SanityExercise {
   _id: string
   name: string
-  description?: string
+  description?: PortableTextBlock[]
   imageUrl?: string
   category: string
   subCategory?: string

--- a/app/components/ExerciseDetailModal.tsx
+++ b/app/components/ExerciseDetailModal.tsx
@@ -2,13 +2,19 @@
 
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
 import { VideoCameraIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { PortableText } from '@portabletext/react'
 import Image from 'next/image'
 import clsx from 'clsx'
 import { CompleteExerciseButton } from './CompleteExerciseButton'
 import { LeftRightToggle } from './LeftRightToggle'
 import { ExerciseTimer } from './ExerciseTimer'
 import { getExerciseVisual } from './exerciseVisuals'
+import { createExerciseDescriptionComponents, isPortableTextBlocks } from './exerciseDescription'
 import { Exercise } from '@/app/types/exercise'
+
+const descriptionComponents = createExerciseDescriptionComponents(
+  'mt-3 text-base leading-relaxed text-slate-600'
+)
 
 interface ExerciseDetailModalProps {
   exercise: Exercise | null
@@ -84,10 +90,8 @@ export function ExerciseDetailModal({
               {exercise.name}
             </DialogTitle>
 
-            {exercise.description && (
-              <p className="mt-3 whitespace-pre-line text-base leading-relaxed text-slate-600">
-                {exercise.description}
-              </p>
+            {isPortableTextBlocks(exercise.description) && (
+              <PortableText value={exercise.description} components={descriptionComponents} />
             )}
 
             <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/app/components/exerciseDescription.tsx
+++ b/app/components/exerciseDescription.tsx
@@ -1,0 +1,37 @@
+import type { PortableTextBlock } from '@portabletext/types'
+import type { PortableTextComponents } from '@portabletext/react'
+import clsx from 'clsx'
+
+/**
+ * Exercise `description` comes back from Prisma typed as `Prisma.JsonValue`
+ * (the column just holds whatever JSON was last synced from Sanity) — this
+ * narrows it to the Portable Text shape we actually expect before handing it
+ * to `<PortableText>`, rather than trusting the value at every call site.
+ */
+export function isPortableTextBlocks(value: unknown): value is PortableTextBlock[] {
+  return Array.isArray(value) && value.length > 0
+}
+
+export function createExerciseDescriptionComponents(paragraphClassName: string): PortableTextComponents {
+  return {
+    block: {
+      normal: ({ children }) => <p className={paragraphClassName}>{children}</p>,
+    },
+    list: {
+      bullet: ({ children }) => (
+        <ul className={clsx(paragraphClassName, 'list-disc space-y-1 pl-5')}>{children}</ul>
+      ),
+      number: ({ children }) => (
+        <ol className={clsx(paragraphClassName, 'list-decimal space-y-1 pl-5')}>{children}</ol>
+      ),
+    },
+    listItem: {
+      bullet: ({ children }) => <li>{children}</li>,
+      number: ({ children }) => <li>{children}</li>,
+    },
+    marks: {
+      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      em: ({ children }) => <em className="italic">{children}</em>,
+    },
+  }
+}

--- a/app/components/sessions/SessionLobby.tsx
+++ b/app/components/sessions/SessionLobby.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
+import type { Prisma } from '@prisma/client'
 
 interface Participant {
   id: string
@@ -13,7 +14,7 @@ interface Participant {
 interface Exercise {
   id: string
   name: string
-  description: string | null
+  description: Prisma.JsonValue | null
   imageUrl: string | null
   category: string
   subCategory: string | null

--- a/app/types/exercise.ts
+++ b/app/types/exercise.ts
@@ -1,9 +1,11 @@
+import type { Prisma } from '@prisma/client'
+
 export interface Exercise {
   id: string
   name: string
-  description: string | null
+  description: Prisma.JsonValue | null
   imageUrl: string | null
   category: string
   subCategory: string | null
   hasLeftRight: boolean
-} 
+}

--- a/lib/sessions/suggestions.ts
+++ b/lib/sessions/suggestions.ts
@@ -1,11 +1,11 @@
 import { prisma } from '@/lib/prisma'
-import type { ExerciseCompletion, Exercise as PrismaExercise } from '@prisma/client'
+import type { ExerciseCompletion, Exercise as PrismaExercise, Prisma } from '@prisma/client'
 import { getCatalogProgress } from '@/lib/exercises/progress'
 
 interface SuggestedExercise {
   id: string
   name: string
-  description: string | null
+  description: Prisma.JsonValue | null
   imageUrl: string | null
   category: string
   subCategory: string | null

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@auth/prisma-adapter": "^2.7.4",
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
+        "@portabletext/react": "^7.0.1",
         "@sanity/image-url": "^1.1.0",
         "@sanity/vision": "^3.68.3",
         "@stripe/stripe-js": "^7.8.0",
@@ -3762,37 +3763,40 @@
       }
     },
     "node_modules/@portabletext/react": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-3.2.0.tgz",
-      "integrity": "sha512-BA216Z8yhb/eP24bfb09uiT0SVnQHTVZMPXf4MRBEZ+G8cMzZM/ab3tcp8owyp91+3kTKR0qSIpzYSKdm1Pakw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-7.0.1.tgz",
+      "integrity": "sha512-NMedRgByZMSbV6dA7tdM6Jom4J/AfV7xIXcZk3kQMs8bCq6faeY9GbjtgYIYsomdjXvNsVIVx3PXvVPpiUa7mA==",
+      "license": "MIT",
       "dependencies": {
-        "@portabletext/toolkit": "^2.0.16",
-        "@portabletext/types": "^2.0.13"
+        "@portabletext/toolkit": "^5.0.2",
+        "@portabletext/types": "^4.0.2"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "react": "^17 || ^18 || >=19.0.0-0"
+        "react": "^19"
       }
     },
     "node_modules/@portabletext/toolkit": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.16.tgz",
-      "integrity": "sha512-aBvnD8MscoAlEIuZBn0Aksd+oCuoMGFOT3CtHIgRBaac0Vu4YnnMUF45xo/B/T5vmwWcnDXoJEJdn+SKDg1m+A==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-5.0.2.tgz",
+      "integrity": "sha512-Njc1LE1PMJkTx/wEPqZ6sOWGgFgX2B47fxpOQ/Ia4ByhsZoA5Sq8dNvvV5F052j/xE8TbOLiBEjS848FkKADDQ==",
+      "license": "MIT",
       "dependencies": {
-        "@portabletext/types": "^2.0.13"
+        "@portabletext/types": "^4.0.2"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@portabletext/types": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.13.tgz",
-      "integrity": "sha512-5xk5MSyQU9CrDho3Rsguj38jhijhD36Mk8S6mZo3huv6PM+t4M/5kJN2KFIxgvt4ONpvOEs1pVIZAV0cL0Vi+Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-djfIGU9n6DRrunlvj2nIDAp17URo/nA4jSXGvf+Gupx8NLLy9fmJBZ3GL8yhqn9lSVc+cKCharjOa3aOBnWbRw==",
+      "license": "MIT",
       "engines": {
-        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
+        "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@prisma/client": {
@@ -12866,6 +12870,43 @@
         "styled-components": "^6.1"
       }
     },
+    "node_modules/next-sanity/node_modules/@portabletext/react": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-3.2.4.tgz",
+      "integrity": "sha512-Gq0BaIBw6PMXnN1M9clG7vOa952O4F+CTfANLH/NaxiH5eI1sOx3IoGoGLnPPUTxCKq3F380gz4ycz6WzMtu0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/toolkit": "^2.0.18",
+        "@portabletext/types": "^2.0.15"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || >=19.0.0-0"
+      }
+    },
+    "node_modules/next-sanity/node_modules/@portabletext/toolkit": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.18.tgz",
+      "integrity": "sha512-m3v2WwKQTNNk5BFZlUuPuCW0Zi6iDSpwrium4Ej5L2FHDXhFuwAyEMPXDrvwPvqjES/oJzcwmdKLMhYa44T9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/next-sanity/node_modules/@portabletext/types": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.15.tgz",
+      "integrity": "sha512-2e6i2gSQsrA/5OL5Gm4/9bxB9MNO73Fa47zj+0mT93xkoQUCGCWX5fZh1YBJ86hszaRYlqvqG08oULxvvPPp/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
+      }
+    },
     "node_modules/next-sanity/node_modules/@sanity/mutate": {
       "version": "0.11.0-canary.4",
       "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.11.0-canary.4.tgz",
@@ -15394,6 +15435,43 @@
       },
       "engines": {
         "node": ">=18.2"
+      }
+    },
+    "node_modules/sanity/node_modules/@portabletext/react": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-3.2.4.tgz",
+      "integrity": "sha512-Gq0BaIBw6PMXnN1M9clG7vOa952O4F+CTfANLH/NaxiH5eI1sOx3IoGoGLnPPUTxCKq3F380gz4ycz6WzMtu0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/toolkit": "^2.0.18",
+        "@portabletext/types": "^2.0.15"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || >=19.0.0-0"
+      }
+    },
+    "node_modules/sanity/node_modules/@portabletext/toolkit": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.18.tgz",
+      "integrity": "sha512-m3v2WwKQTNNk5BFZlUuPuCW0Zi6iDSpwrium4Ej5L2FHDXhFuwAyEMPXDrvwPvqjES/oJzcwmdKLMhYa44T9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/sanity/node_modules/@portabletext/types": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.15.tgz",
+      "integrity": "sha512-2e6i2gSQsrA/5OL5Gm4/9bxB9MNO73Fa47zj+0mT93xkoQUCGCWX5fZh1YBJ86hszaRYlqvqG08oULxvvPPp/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
       }
     },
     "node_modules/sanity/node_modules/json5": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@auth/prisma-adapter": "^2.7.4",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
+    "@portabletext/react": "^7.0.1",
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.68.3",
     "@stripe/stripe-js": "^7.8.0",

--- a/prisma/migrations/20260809165233_exercise_description_json/migration.sql
+++ b/prisma/migrations/20260809165233_exercise_description_json/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+-- Converts exercises.description from text to jsonb to hold Portable Text
+-- (rich text) blocks synced from Sanity. Existing plain-text values are
+-- preserved as JSON string scalars (via to_jsonb) rather than dropped, so
+-- nothing is lost before the Sanity data migration + resync overwrites them
+-- with proper Portable Text block arrays.
+ALTER TABLE "public"."exercises"
+  ALTER COLUMN "description" TYPE JSONB USING to_jsonb("description");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Exercise {
   id          String   @id @default(cuid())
   sanityId    String   @unique
   name        String
-  description String?
+  description Json?
   imageUrl    String?
   category    String
   subCategory String?

--- a/sanity/schemaTypes/exercise.ts
+++ b/sanity/schemaTypes/exercise.ts
@@ -14,7 +14,24 @@ const exercise = {
     {
       name: 'description',
       title: 'Description',
-      type: 'text',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: 'Normal', value: 'normal' }],
+          lists: [
+            { title: 'Bullet', value: 'bullet' },
+            { title: 'Numbered', value: 'number' },
+          ],
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+            ],
+            annotations: [],
+          },
+        },
+      ],
     },
     {
       name: 'image',

--- a/scripts/migrate-exercise-description-to-blocks.mjs
+++ b/scripts/migrate-exercise-description-to-blocks.mjs
@@ -1,0 +1,86 @@
+// One-off migration: converts the `exercise.description` field in Sanity
+// from a plain string to a Portable Text block array, to match the schema
+// change in sanity/schemaTypes/exercise.ts (rich text description).
+//
+// Usage:
+//   node --env-file=.env.local scripts/migrate-exercise-description-to-blocks.mjs           # dry run, prints what would change
+//   node --env-file=.env.local scripts/migrate-exercise-description-to-blocks.mjs --commit   # actually patches the documents
+//
+// Requires NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET, and a
+// write-enabled NEXT_PUBLIC_SANITY_TOKEN in the environment (same vars
+// sanity/lib/client.ts uses).
+
+import { createClient } from 'next-sanity'
+import { randomUUID } from 'node:crypto'
+
+const commit = process.argv.includes('--commit')
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET
+const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2024-02-13'
+const token = process.env.NEXT_PUBLIC_SANITY_TOKEN
+
+if (!projectId || !dataset || !token) {
+  console.error(
+    'Missing NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET, or NEXT_PUBLIC_SANITY_TOKEN in the environment.'
+  )
+  process.exit(1)
+}
+
+const client = createClient({ projectId, dataset, apiVersion, token, useCdn: false })
+
+function stringToBlocks(text) {
+  return text
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    .map((paragraph) => ({
+      _type: 'block',
+      _key: randomUUID(),
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          _key: randomUUID(),
+          text: paragraph.replace(/\\n/g, '\n'),
+          marks: [],
+        },
+      ],
+    }))
+}
+
+async function main() {
+  const exercises = await client.fetch(`*[_type == "exercise" && defined(description)]{_id, name, description}`)
+  const legacy = exercises.filter((exercise) => typeof exercise.description === 'string')
+
+  console.log(`Found ${exercises.length} exercises with a description, ${legacy.length} still plain text.`)
+
+  if (legacy.length === 0) {
+    console.log('Nothing to migrate.')
+    return
+  }
+
+  for (const exercise of legacy) {
+    const blocks = stringToBlocks(exercise.description)
+    console.log(`\n${exercise.name} (${exercise._id})`)
+    console.log('  before:', JSON.stringify(exercise.description))
+    console.log('  after: ', JSON.stringify(blocks.map((b) => b.children[0].text)))
+
+    if (commit) {
+      await client.patch(exercise._id).set({ description: blocks }).commit()
+      console.log('  -> patched')
+    }
+  }
+
+  if (!commit) {
+    console.log('\nDry run only — rerun with --commit to apply these patches.')
+  } else {
+    console.log(`\nPatched ${legacy.length} exercises.`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Sanity's `exercise.description` field is now Portable Text (bold/italic, bullet/numbered lists) instead of plain `text`, so multi-step instructions (e.g. "Phase 1 / Phase 2 / Phase 3") can be formatted instead of relying on `whitespace-pre-line`.
- Postgres `exercises.description` column moved from `text` to `jsonb` (migration `20260809165233_exercise_description_json`, already applied to the shared dev/preview/prod database) to carry the blocks through the existing Sanity → Postgres sync webhook.
- Both exercise-facing surfaces — the exercise detail modal and the category/subcategory grid — render the rich text via a shared `PortableText` config (`app/components/exerciseDescription.tsx`).
- Added `scripts/migrate-exercise-description-to-blocks.mjs`, a one-off script (dry-run by default, `--commit` to apply) to convert the ~85 existing plain-text Sanity descriptions into Portable Text blocks.

## Test plan
- [x] `npx tsc --noEmit` and `eslint` pass clean
- [x] DB migration applied and verified against the live database (`information_schema.columns` shows `jsonb`; existing values read back correctly via Prisma, preserved as JSON string scalars rather than dropped)
- [x] Full `pg_dump` backup taken before the migration (`db-backups/verceldb_pre_description_richtext_*.sql`, gitignored)
- [ ] Run `scripts/migrate-exercise-description-to-blocks.mjs` (dry run, then `--commit`) to convert existing Sanity descriptions to blocks
- [ ] Trigger a resync (`GET /api/sync-exercises`) and confirm rich text renders correctly in the modal and grid card for an exercise with bold/list formatting
- [ ] Confirm an exercise with no description still renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)