### PR TITLE
Gate bonus exercises behind monthly plan completion

### DIFF
--- a/app/components/CatalogProgressRing.tsx
+++ b/app/components/CatalogProgressRing.tsx
@@ -10,11 +10,11 @@ const RADIUS = (SIZE - STROKE_WIDTH) / 2
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS
 
 /**
- * Dashboard stat card showing this month's progress through the exercise
- * catalog: how many distinct exercises this user has completed within the
- * last 30 days, out of the total catalog size, as a circular progress
- * indicator. The goal is cycling through the whole catalog every month, not
- * lifetime completion — see `getCatalogProgress` for why.
+ * Dashboard stat card showing this month's progress through the required
+ * plan: how many distinct Conditioning and Restorative exercises this user has
+ * completed within the last 30 days, out of the plan's total size, as a
+ * circular progress indicator. Bonus categories are excluded — see
+ * `getCatalogProgress` for why.
  */
 export async function CatalogProgressRing({ userId }: CatalogProgressRingProps) {
   const { completedCount, totalCount } = await getCatalogProgress(userId)
@@ -34,7 +34,7 @@ export async function CatalogProgressRing({ userId }: CatalogProgressRingProps) 
           viewBox={`0 0 ${SIZE} ${SIZE}`}
           className="-rotate-90"
           role="img"
-          aria-label={`${completedCount} of ${totalCount} exercises completed this month`}
+          aria-label={`${completedCount} of ${totalCount} monthly plan exercises completed this month`}
         >
           <circle
             cx={SIZE / 2}
@@ -77,8 +77,8 @@ export async function CatalogProgressRing({ userId }: CatalogProgressRingProps) 
           {!hasCatalog
             ? 'No exercises in the catalog yet.'
             : isComplete
-            ? "You've cycled through the entire catalog this month. Incredible work!"
-            : `${remaining} exercise${remaining === 1 ? '' : 's'} away from completing the whole catalog this month.`}
+            ? "You've completed your whole monthly plan. Incredible work!"
+            : `${remaining} exercise${remaining === 1 ? '' : 's'} away from completing your monthly plan.`}
         </p>
       </div>
     </div>

--- a/app/components/DailySuggestions.tsx
+++ b/app/components/DailySuggestions.tsx
@@ -10,13 +10,14 @@ type DailySuggestionsProps = {
 }
 
 export async function DailySuggestions({ userId, preloaded }: DailySuggestionsProps) {
-  const { suggestedExercises, completedExercises } =
+  const { suggestedExercises, completedExercises, bonusExercises } =
     preloaded ?? (await getDashboardDailySuggestionsPayload(userId))
 
   return (
     <DailySuggestionsClient
       initialSuggestedExercises={suggestedExercises}
       completedExercises={completedExercises}
+      bonusExercises={bonusExercises}
     />
   )
 } 

--- a/app/components/DailySuggestionsClient.tsx
+++ b/app/components/DailySuggestionsClient.tsx
@@ -5,7 +5,8 @@ import { CheckIcon } from '@heroicons/react/20/solid'
 import { FlagIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 import { ExerciseDetailModal } from './ExerciseDetailModal'
-import { getExerciseVisual } from './exerciseVisuals'
+import { getExerciseVisual, BONUS_SECTION_VISUAL } from './exerciseVisuals'
+import { isBonusCategory } from '@/lib/exercises/categories'
 import { Exercise } from '@/app/types/exercise'
 
 interface DailySuggestionsClientProps {
@@ -15,24 +16,39 @@ interface DailySuggestionsClientProps {
     createdAt: Date
     exercise: Exercise
   }[]
+  bonusExercises?: Exercise[]
 }
 
+const BONUS_GROUP = 'bonus'
+
 // Conditioning is shown before Restorative to match the order used
-// elsewhere in the app (e.g. the dashboard's category browse cards).
-// Any other category value falls back to the order it's first seen in.
-const CATEGORY_ORDER = ['conditioning', 'restorative']
+// elsewhere in the app (e.g. the dashboard's category browse cards), with
+// bonus work last. Any other category value falls back to the order it's
+// first seen in.
+const CATEGORY_ORDER = ['conditioning', 'restorative', BONUS_GROUP]
+
+// Every bonus category collapses into one group so the timeline shows a
+// single "Bonus Exercises" heading rather than one heading per bonus
+// category. Items still render their own category on their chip.
+function groupKeyFor(exercise: Exercise) {
+  return isBonusCategory(exercise.category) ? BONUS_GROUP : exercise.category
+}
 
 function groupExercisesByCategory(exercises: Exercise[]) {
-  const seenCategories = Array.from(new Set(exercises.map((exercise) => exercise.category)))
-  const orderedCategories = [
-    ...CATEGORY_ORDER.filter((category) => seenCategories.includes(category)),
-    ...seenCategories.filter((category) => !CATEGORY_ORDER.includes(category)),
+  const seenGroups = Array.from(new Set(exercises.map(groupKeyFor)))
+  const orderedGroups = [
+    ...CATEGORY_ORDER.filter((group) => seenGroups.includes(group)),
+    ...seenGroups.filter((group) => !CATEGORY_ORDER.includes(group)),
   ]
 
-  return orderedCategories.map((category) => ({
-    category,
-    exercises: exercises.filter((exercise) => exercise.category === category),
+  return orderedGroups.map((group) => ({
+    category: group,
+    exercises: exercises.filter((exercise) => groupKeyFor(exercise) === group),
   }))
+}
+
+function getSectionVisual(group: string) {
+  return group === BONUS_GROUP ? BONUS_SECTION_VISUAL : getExerciseVisual(group, null)
 }
 
 // The day's suggestions are a fixed set for the session: whatever was
@@ -82,9 +98,13 @@ function buildCompletionMessage(
 export function DailySuggestionsClient({
   initialSuggestedExercises,
   completedExercises,
+  bonusExercises = [],
 }: DailySuggestionsClientProps) {
   const [displayedExercises] = useState<Exercise[]>(() =>
-    mergeSuggestedWithCompleted(initialSuggestedExercises, completedExercises)
+    mergeSuggestedWithCompleted(
+      [...initialSuggestedExercises, ...bonusExercises],
+      completedExercises
+    )
   )
   const [completedIds, setCompletedIds] = useState<Set<string>>(
     () => new Set(completedExercises.map((c) => c.exercise.id))
@@ -120,11 +140,12 @@ export function DailySuggestionsClient({
     setCompletedAtById((prev) => ({ ...prev, [exerciseId]: new Date() }))
 
     if (exercise) {
+      const group = groupKeyFor(exercise)
       const remainingInCategory = displayedExercises.filter(
-        (e) => e.category === exercise.category && !updatedIds.has(e.id)
+        (e) => groupKeyFor(e) === group && !updatedIds.has(e.id)
       ).length
       const remainingTotal = displayedExercises.filter((e) => !updatedIds.has(e.id)).length
-      const categoryLabel = getExerciseVisual(exercise.category, null).label
+      const categoryLabel = getSectionVisual(group).label
       setCompletionMessage(buildCompletionMessage(categoryLabel, remainingInCategory, remainingTotal))
     }
   }
@@ -140,7 +161,7 @@ export function DailySuggestionsClient({
       <div className="mx-auto max-w-xl rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
         <ol className="relative">
           {groupExercisesByCategory(displayedExercises).map((group, groupIndex, groups) => {
-            const sectionVisual = getExerciseVisual(group.category, null)
+            const sectionVisual = getSectionVisual(group.category)
             const isLastGroup = groupIndex === groups.length - 1
 
             return (

--- a/app/components/exerciseVisuals.ts
+++ b/app/components/exerciseVisuals.ts
@@ -7,6 +7,12 @@ import {
   ArrowPathIcon,
   SparklesIcon,
   MoonIcon,
+  AdjustmentsHorizontalIcon,
+  BoltIcon,
+  HandRaisedIcon,
+  RectangleStackIcon,
+  ShieldCheckIcon,
+  GiftIcon,
 } from '@heroicons/react/24/outline'
 
 export type ExerciseVisual = {
@@ -27,6 +33,23 @@ const SUBCATEGORY_VISUALS: Record<string, ExerciseVisual> = {
 const CATEGORY_VISUALS: Record<string, ExerciseVisual> = {
   conditioning: { icon: SparklesIcon, badgeClass: 'bg-blue-600', tagClass: 'bg-blue-50 text-blue-700', label: 'Conditioning' },
   restorative: { icon: MoonIcon, badgeClass: 'bg-teal-600', tagClass: 'bg-teal-50 text-teal-700', label: 'Restorative' },
+  jointMobility: { icon: AdjustmentsHorizontalIcon, badgeClass: 'bg-indigo-500', tagClass: 'bg-indigo-50 text-indigo-700', label: 'Joint Mobility' },
+  cardio: { icon: BoltIcon, badgeClass: 'bg-orange-500', tagClass: 'bg-orange-50 text-orange-700', label: 'Cardio' },
+  upperBodyStrength: { icon: HandRaisedIcon, badgeClass: 'bg-purple-500', tagClass: 'bg-purple-50 text-purple-700', label: 'Upper Body Strength' },
+  lowerBodyStrength: { icon: RectangleStackIcon, badgeClass: 'bg-emerald-600', tagClass: 'bg-emerald-50 text-emerald-700', label: 'Lower Body Strength' },
+  core: { icon: ShieldCheckIcon, badgeClass: 'bg-cyan-600', tagClass: 'bg-cyan-50 text-cyan-700', label: 'Core' },
+}
+
+/**
+ * Heading for the single section every bonus exercise sits under, regardless
+ * of which bonus category it belongs to. Amber echoes the completed-ring and
+ * month-completion palette, since the section only unlocks at 100%.
+ */
+export const BONUS_SECTION_VISUAL: ExerciseVisual = {
+  icon: GiftIcon,
+  badgeClass: 'bg-amber-500',
+  tagClass: 'bg-amber-50 text-amber-700',
+  label: 'Bonus Exercises',
 }
 
 const DEFAULT_VISUAL: ExerciseVisual = {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -75,7 +75,7 @@ export default async function Dashboard() {
           </p>
         </div>
 
-        {suggestionsPayload.fullLibraryCompleteInRollingWindow && (
+        {suggestionsPayload.requiredPlanCompleteInRollingWindow && (
           <MonthCompletionCelebration />
         )}
 

--- a/lib/exercises/categories.ts
+++ b/lib/exercises/categories.ts
@@ -1,0 +1,29 @@
+/**
+ * Splits the exercise catalog into the required monthly plan and optional
+ * bonus work.
+ *
+ * Conditioning and Restorative are what keep connective tissue in a state of
+ * growth across the rolling 30-day window — those are the plan. Everything
+ * else is extra: hidden until a student has finished the plan, and never
+ * counted toward their progress ring.
+ *
+ * Values must match the `category` option list in
+ * `sanity/schemaTypes/exercise.ts`. A category present in neither list is
+ * unreachable — it will never be suggested and never counted.
+ */
+
+export const REQUIRED_CATEGORIES = ['conditioning', 'restorative'] as const
+
+export const BONUS_CATEGORIES = [
+  'jointMobility',
+  'cardio',
+  'upperBodyStrength',
+  'lowerBodyStrength',
+  'core',
+] as const
+
+const BONUS_CATEGORY_SET: ReadonlySet<string> = new Set(BONUS_CATEGORIES)
+
+export function isBonusCategory(category: string): boolean {
+  return BONUS_CATEGORY_SET.has(category)
+}

--- a/lib/exercises/progress.ts
+++ b/lib/exercises/progress.ts
@@ -1,19 +1,25 @@
 import { prisma } from '@/lib/prisma'
+import { REQUIRED_CATEGORIES } from '@/lib/exercises/categories'
 
 export type CatalogProgress = {
-  /** Count of distinct exercises this user has completed within the last 30 days. */
+  /** Count of distinct required-plan exercises this user has completed within the last 30 days. */
   completedCount: number
-  /** Total number of exercises currently in the catalog. */
+  /** Total number of required-plan exercises currently in the catalog. */
   totalCount: number
 }
 
 /**
- * Returns how many distinct exercises in the catalog this user has completed
- * within the rolling 30-day window, versus the total size of the catalog.
+ * Returns how many distinct exercises in the *required plan* this user has
+ * completed within the rolling 30-day window, versus the size of that plan.
  *
- * The goal this ring tracks is cycling through the *entire* catalog within a
- * month (that's what keeps connective tissue in a state of growth) — not
- * lifetime completion. `ExerciseCompletion` is a one-time flag per
+ * The goal this ring tracks is cycling through every Conditioning and
+ * Restorative exercise within a month (that's what keeps connective tissue in
+ * a state of growth) — not lifetime completion, and not the whole catalog.
+ * Bonus categories (see `lib/exercises/categories.ts`) are excluded from both
+ * the numerator and the denominator, so optional work can neither inflate the
+ * ring's total nor move the needle on it.
+ *
+ * `ExerciseCompletion` is a one-time flag per
  * user+exercise (`@@unique([userId, exerciseId])`); `createdAt` gets
  * refreshed (deleted + recreated) whenever the exercise is re-completed after
  * 30+ days, per `app/api/exercises/complete/route.ts`. So filtering to rows
@@ -28,9 +34,15 @@ export async function getCatalogProgress(userId: string): Promise<CatalogProgres
 
   const [completedCount, totalCount] = await Promise.all([
     prisma.exerciseCompletion.count({
-      where: { userId, createdAt: { gte: thirtyDaysAgo } },
+      where: {
+        userId,
+        createdAt: { gte: thirtyDaysAgo },
+        exercise: { category: { in: [...REQUIRED_CATEGORIES] } },
+      },
     }),
-    prisma.exercise.count(),
+    prisma.exercise.count({
+      where: { category: { in: [...REQUIRED_CATEGORIES] } },
+    }),
   ])
 
   return { completedCount, totalCount }

--- a/lib/sessions/suggestions.ts
+++ b/lib/sessions/suggestions.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@/lib/prisma'
-import type { ExerciseCompletion, Exercise as PrismaExercise, Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
+import type { ExerciseCompletion, Exercise as PrismaExercise } from '@prisma/client'
 import { getCatalogProgress } from '@/lib/exercises/progress'
+import { BONUS_CATEGORIES, REQUIRED_CATEGORIES } from '@/lib/exercises/categories'
 
 interface SuggestedExercise {
   id: string
@@ -17,16 +19,20 @@ export type DashboardCompletionWithExercise = ExerciseCompletion & {
 }
 
 export type DashboardDailySuggestionsPayload = {
+  /** Today's required-plan suggestions (Conditioning + Restorative only). */
   suggestedExercises: SuggestedExercise[]
   completedExercises: DashboardCompletionWithExercise[]
-  /** Every catalog exercise has a completion within the rolling month window (matches suggestions SQL). */
-  fullLibraryCompleteInRollingWindow: boolean
+  /** Every required-plan exercise has a completion within the rolling month window. */
+  requiredPlanCompleteInRollingWindow: boolean
+  /** Optional extras, non-empty only once the required plan is complete. */
+  bonusExercises: SuggestedExercise[]
 }
 
 /**
  * Returns one un-completed exercise per category/subcategory group for the
- * given user, excluding anything completed in the last month. Within each
- * group, exercises that have gone longest without being completed are
+ * given user, limited to `categories` and excluding anything completed in the
+ * last month. Within each group, exercises that have gone longest without
+ * being completed are
  * prioritized (never-completed exercises rank above ones the user is merely
  * eligible for again after the cooldown), with a random tiebreak among
  * exercises that are equally overdue (e.g. multiple never-completed in the
@@ -42,8 +48,11 @@ export type DashboardDailySuggestionsPayload = {
  */
 export async function getSuggestedExercises(
   userId: string,
-  todayStart: Date
+  todayStart: Date,
+  categories: readonly string[]
 ): Promise<SuggestedExercise[]> {
+  if (categories.length === 0) return []
+
   return prisma.$queryRaw<SuggestedExercise[]>`
     WITH LastCompletion AS (
       SELECT ec."exerciseId", MAX(ec."createdAt") AS last_completed_at
@@ -68,7 +77,8 @@ export async function getSuggestedExercises(
         ) as rn
       FROM exercises e
       LEFT JOIN LastCompletion lc ON lc."exerciseId" = e.id
-      WHERE (lc.last_completed_at IS NULL OR lc.last_completed_at < NOW() - INTERVAL '1 month')
+      WHERE e.category IN (${Prisma.join(categories)})
+        AND (lc.last_completed_at IS NULL OR lc.last_completed_at < NOW() - INTERVAL '1 month')
         AND NOT EXISTS (
           SELECT 1 FROM CompletedTodaySlots cts
           WHERE cts.category = e.category
@@ -117,13 +127,17 @@ export async function getEligibleExercises(userId: string): Promise<SuggestedExe
 
 /**
  * Loads dashboard daily-suggestion data in one round trip where possible.
- * `fullLibraryCompleteInRollingWindow` is true when the user has a completion
- * dated within the rolling one-month window for every exercise in the catalog
- * (same rule as category pages and `/api/exercises/complete`) — this is
- * intentionally derived from `getCatalogProgress`, not from
- * `suggestedExercises` being empty, since `suggestedExercises` now also goes
- * empty just from finishing today's slots (see `getSuggestedExercises`),
- * which is a much smaller bar than the whole catalog.
+ *
+ * `requiredPlanCompleteInRollingWindow` is true when the user has a completion
+ * dated within the rolling one-month window for every Conditioning and
+ * Restorative exercise (same rule as category pages and
+ * `/api/exercises/complete`) — this is intentionally derived from
+ * `getCatalogProgress`, not from `suggestedExercises` being empty, since
+ * `suggestedExercises` also goes empty just from finishing today's slots (see
+ * `getSuggestedExercises`), which is a much smaller bar than the whole plan.
+ *
+ * Bonus exercises are only fetched once that flag is true, so students still
+ * working through the plan neither see extras nor pay for the extra query.
  */
 export async function getDashboardDailySuggestionsPayload(
   userId: string
@@ -132,7 +146,7 @@ export async function getDashboardDailySuggestionsPayload(
   today.setHours(0, 0, 0, 0)
 
   const [suggestedExercises, completedExercises, catalogProgress] = await Promise.all([
-    getSuggestedExercises(userId, today),
+    getSuggestedExercises(userId, today, REQUIRED_CATEGORIES),
     prisma.exerciseCompletion.findMany({
       where: {
         userId,
@@ -143,12 +157,17 @@ export async function getDashboardDailySuggestionsPayload(
     getCatalogProgress(userId),
   ])
 
-  const fullLibraryCompleteInRollingWindow =
+  const requiredPlanCompleteInRollingWindow =
     catalogProgress.totalCount > 0 && catalogProgress.completedCount >= catalogProgress.totalCount
+
+  const bonusExercises = requiredPlanCompleteInRollingWindow
+    ? await getSuggestedExercises(userId, today, BONUS_CATEGORIES)
+    : []
 
   return {
     suggestedExercises,
     completedExercises,
-    fullLibraryCompleteInRollingWindow,
+    requiredPlanCompleteInRollingWindow,
+    bonusExercises,
   }
 }

--- a/sanity/schemaTypes/exercise.ts
+++ b/sanity/schemaTypes/exercise.ts
@@ -45,6 +45,9 @@ const exercise = {
       name: 'category',
       title: 'Category',
       type: 'string',
+      // Adding an option here also requires adding it to REQUIRED_CATEGORIES
+      // or BONUS_CATEGORIES in lib/exercises/categories.ts, or exercises in
+      // that category will never surface in the app.
       options: {
         list: [
           { title: 'Conditioning', value: 'conditioning' },


### PR DESCRIPTION
## Why

Conditioning and Restorative are the required monthly plan — the movements that keep connective tissue in a state of growth across the rolling 30-day window. Everything else in the catalog (Joint Mobility, Cardio, Upper/Lower Body Strength, Core) is optional extra work.

The app didn't encode that distinction, so extras leaked into the daily timeline for students who hadn't finished the plan yet, labeled with a generic `EXERCISE` heading repeated once per bonus category. Seeing optional work presented as part of the daily requirement makes the plan look bigger than it is.

## What was wrong

1. **`getSuggestedExercises` had no category filter** — it emitted one suggestion per `(category, subCategory)` group across all 7 categories, so bonus exercises showed up every day alongside required work.
2. **Bonus categories had no visual entry** — each fell through to `DEFAULT_VISUAL` (label `"Exercise"`), and since the timeline groups by category, five bonus categories rendered as five separate sections all headed `EXERCISE`.
3. **The progress ring counted the whole catalog** — `getCatalogProgress` used `prisma.exercise.count()`, so optional work inflated both the numerator and the denominator.

## What changed

- **`lib/exercises/categories.ts`** (new) — single source of truth for `REQUIRED_CATEGORIES` / `BONUS_CATEGORIES`, with a pointer comment added to the Sanity schema so a new category option can't silently become unreachable.
- **`getCatalogProgress`** now counts required categories only, on both sides. Bonus work can't move the ring.
- **`getSuggestedExercises`** takes a category list. The dashboard requests required categories, and only issues the bonus query once the ring reads 100% — so students mid-plan neither see extras nor pay for the extra round trip.
- **Bonus items collapse into one "Bonus Exercises" section** rather than one heading per category. Each item's chip shows its real category name (Joint Mobility, Cardio, …), which also required adding proper visuals for the five bonus categories.
- `fullLibraryCompleteInRollingWindow` → `requiredPlanCompleteInRollingWindow`, since its meaning changed.

## Deliberately unchanged

- **The Conditioning and Restorative browse cards** at the bottom of the dashboard. Those two categories *are* the plan, not extras, so they stay always-visible.
- **`getEligibleExercises`** — it returns all categories, but its only consumer (group-session plan generation) already narrows to conditioning/restorative via `pickBalancedBySubcategory`, so bonus rows in that pool are inert.
- **No browse pages for bonus categories** — `app/[category]` still only accepts conditioning/restorative. Timeline items open a modal and do no routing, so bonus items are safe to render without new routes.

## Verification

`npx tsc --noEmit` and `npm run build` both pass clean.

Current catalog is 43 conditioning + 48 restorative (91 required) and 4 bonus (3 core, 1 joint mobility), so the ring's denominator moves 95 → 91.

Browser verification was **not** completed: the only database reachable from this environment is production, and confirming the unlocked state would have meant writing fake completion rows into a real student's history. Please check both states on the Vercel preview — in particular that the gate-open state shows exactly one "Bonus Exercises" heading, and that completing a bonus exercise leaves the ring at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)