### PR TITLE
feat(timer): sound a chime when the exercise timer completes

### DIFF
--- a/app/components/ExerciseTimer.tsx
+++ b/app/components/ExerciseTimer.tsx
@@ -1,9 +1,18 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ClockIcon, PauseIcon, PlayIcon, ArrowPathIcon } from '@heroicons/react/24/outline'
+import {
+  ClockIcon,
+  PauseIcon,
+  PlayIcon,
+  ArrowPathIcon,
+  SpeakerWaveIcon,
+  SpeakerXMarkIcon,
+} from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 import { TIMER_PHASES, TIMER_TOTAL_SECONDS, getPhaseForElapsed } from '@/lib/exercises/timerPhases'
+import { createChimePlayer, type ChimePlayer } from '@/lib/exercises/completionChime'
+import { readSoundEnabled, writeSoundEnabled } from '@/lib/preferences/soundPreference'
 
 const SIZE = 176
 const STROKE_WIDTH = 12
@@ -40,10 +49,24 @@ function tickPoint(boundarySeconds: number, radius: number) {
 export function ExerciseTimer() {
   const [status, setStatus] = useState<TimerStatus>('idle')
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  // Assume sound is on for the first render and reconcile from localStorage in an
+  // effect — reading storage during render would differ from the server pass.
+  const [soundEnabled, setSoundEnabled] = useState(true)
 
   const rafRef = useRef<number | null>(null)
   const startTimestampRef = useRef<number | null>(null)
   const accumulatedSecondsRef = useRef(0)
+  const chimeRef = useRef<ChimePlayer | null>(null)
+  // Wall-clock time the run is due to finish, kept independent of the rAF loop so
+  // the chime's schedule survives the loop being throttled in a background tab.
+  const completionDeadlineRef = useRef<number | null>(null)
+
+  const getChime = useCallback(() => {
+    if (!chimeRef.current) {
+      chimeRef.current = createChimePlayer()
+    }
+    return chimeRef.current
+  }, [])
 
   const stopLoop = useCallback(() => {
     if (rafRef.current !== null) {
@@ -67,14 +90,56 @@ export function ExerciseTimer() {
     rafRef.current = requestAnimationFrame(tick)
   }, [stopLoop])
 
-  useEffect(() => stopLoop, [stopLoop])
+  useEffect(() => {
+    setSoundEnabled(readSoundEnabled())
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      stopLoop()
+      chimeRef.current?.dispose()
+    }
+  }, [stopLoop])
+
+  /**
+   * Rescues the chime when the browser suspended the audio context while the tab was
+   * hidden — most likely on a locked phone — and silently dropped the scheduled
+   * strike. A suspended context freezes its clock, so an audio clock that never
+   * reached the strike time is proof the sound never happened.
+   */
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return
+
+      const deadline = completionDeadlineRef.current
+      const chime = chimeRef.current
+      if (deadline === null || chime === null || Date.now() < deadline) return
+
+      if (soundEnabled && !chime.hasSounded()) {
+        chime.playNow()
+      }
+      completionDeadlineRef.current = null
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [soundEnabled])
 
   const handleStart = () => {
     accumulatedSecondsRef.current = 0
     startTimestampRef.current = performance.now()
+    completionDeadlineRef.current = Date.now() + TIMER_TOTAL_SECONDS * 1000
     setElapsedSeconds(0)
     setStatus('running')
     rafRef.current = requestAnimationFrame(tick)
+
+    // This tap is the user gesture that lets audio play at all, so unlock here even
+    // when muted — otherwise unmuting mid-run would have nothing to schedule against.
+    const chime = getChime()
+    chime.unlock()
+    if (soundEnabled) {
+      chime.scheduleIn(TIMER_TOTAL_SECONDS)
+    }
   }
 
   const handlePause = () => {
@@ -82,21 +147,50 @@ export function ExerciseTimer() {
       accumulatedSecondsRef.current += (performance.now() - startTimestampRef.current) / 1000
     }
     stopLoop()
+    chimeRef.current?.cancel()
+    completionDeadlineRef.current = null
     setStatus('paused')
   }
 
   const handleResume = () => {
+    const remainingSeconds = Math.max(0, TIMER_TOTAL_SECONDS - accumulatedSecondsRef.current)
     startTimestampRef.current = performance.now()
+    completionDeadlineRef.current = Date.now() + remainingSeconds * 1000
     setStatus('running')
     rafRef.current = requestAnimationFrame(tick)
+
+    if (soundEnabled) {
+      getChime().scheduleIn(remainingSeconds)
+    }
   }
 
   const handleReset = () => {
     stopLoop()
+    chimeRef.current?.cancel()
+    completionDeadlineRef.current = null
     startTimestampRef.current = null
     accumulatedSecondsRef.current = 0
     setElapsedSeconds(0)
     setStatus('idle')
+  }
+
+  const handleToggleSound = () => {
+    const nextEnabled = !soundEnabled
+    setSoundEnabled(nextEnabled)
+    writeSoundEnabled(nextEnabled)
+
+    if (!nextEnabled) {
+      chimeRef.current?.cancel()
+      return
+    }
+
+    const chime = getChime()
+    chime.unlock()
+
+    const deadline = completionDeadlineRef.current
+    if (status === 'running' && deadline !== null) {
+      chime.scheduleIn((deadline - Date.now()) / 1000)
+    }
   }
 
   if (status === 'idle') {
@@ -212,7 +306,27 @@ export function ExerciseTimer() {
           <ArrowPathIcon className="h-4 w-4" />
           {status === 'done' ? 'Start Again' : 'Reset'}
         </button>
+        <button
+          type="button"
+          onClick={handleToggleSound}
+          aria-label="Completion sound"
+          aria-pressed={soundEnabled}
+          title={soundEnabled ? 'Completion sound on' : 'Completion sound off'}
+          className={clsx(
+            'inline-flex items-center rounded-full bg-white p-2 shadow-sm ring-1 ring-inset ring-slate-200 hover:bg-slate-100',
+            soundEnabled ? 'text-slate-700' : 'text-slate-400'
+          )}
+        >
+          {soundEnabled ? (
+            <SpeakerWaveIcon className="h-4 w-4" />
+          ) : (
+            <SpeakerXMarkIcon className="h-4 w-4" />
+          )}
+        </button>
       </div>
+      <p className="text-xs text-slate-400">
+        {soundEnabled ? 'A chime sounds when the timer finishes' : 'Completion chime muted'}
+      </p>
     </div>
   )
 }

--- a/lib/exercises/completionChime.ts
+++ b/lib/exercises/completionChime.ts
@@ -1,0 +1,271 @@
+/**
+ * The exercise timer's completion chime — a struck singing bowl synthesised with
+ * the Web Audio API, so there is no audio asset to ship, license, or cache.
+ *
+ * The chime is *pre-scheduled* rather than played on demand. The timer's countdown
+ * runs on requestAnimationFrame, which browsers throttle or pause when the tab is
+ * backgrounded, so reacting to the countdown reaching zero would sound the chime
+ * late — precisely when the user is least able to watch the screen. The Web Audio
+ * clock runs on its own thread, independent of rAF and the main thread, so a chime
+ * scheduled at start time sounds on the beat whether or not the UI is still ticking.
+ *
+ * Caveat this cannot solve: if the browser suspends the AudioContext outright
+ * (typically iOS with the screen locked), nothing scheduled will sound. Callers
+ * should keep their own deadline and call playNow() on return to the foreground.
+ */
+
+/** Total ring-out, in seconds, from the first strike to silence. */
+export const CHIME_DURATION_SECONDS = 10
+
+/** Peak output of the whole chime. Deliberately gentle — this often plays on headphones. */
+const MASTER_GAIN = 0.3
+
+/** Rounds off the digital edge of the upper partials. */
+const LOWPASS_HZ = 3200
+
+/** Ramp in over a few milliseconds so the strike doesn't start with a click. */
+const ATTACK_SECONDS = 0.006
+
+/** exponentialRampToValueAtTime cannot reach 0, so decays land here instead. */
+const SILENCE = 0.0001
+
+const DEFAULT_FUNDAMENTAL_HZ = 466.16
+
+/**
+ * One component tone of a strike. Real bells are inharmonic — their partials sit at
+ * irrational-ish ratios rather than integer harmonics, and the high ones fade much
+ * faster than the low ones. That decay gradient is what the ear hears as "bell"
+ * rather than "beep", so `decay` matters as much as `ratio` here.
+ */
+interface ChimePartial {
+  ratio: number
+  gain: number
+  decaySeconds: number
+}
+
+const PARTIALS: ChimePartial[] = [
+  { ratio: 0.5, gain: 0.55, decaySeconds: 10 }, // hum — the long tail under everything
+  { ratio: 1, gain: 1, decaySeconds: 8.5 }, // prime
+  { ratio: 1.19, gain: 0.42, decaySeconds: 4.5 }, // tierce, the bell's minor-third colour
+  { ratio: 1.5, gain: 0.26, decaySeconds: 3 }, // quint
+  { ratio: 2, gain: 0.18, decaySeconds: 2.2 }, // nominal
+  { ratio: 2.66, gain: 0.09, decaySeconds: 1.3 },
+  { ratio: 3.35, gain: 0.05, decaySeconds: 0.8 }, // strike transient shimmer
+]
+
+/** A second, softer strike gives the two-tone feel of a bowl struck by hand. */
+const STRIKES: { delaySeconds: number; velocity: number }[] = [
+  { delaySeconds: 0, velocity: 1 },
+  { delaySeconds: 0.85, velocity: 0.5 },
+]
+
+type AudioContextConstructor = new () => AudioContext
+
+interface ScheduledChime {
+  oscillators: OscillatorNode[]
+  master: GainNode
+}
+
+export interface ChimePlayer {
+  /**
+   * Creates and resumes the AudioContext. Must be called from inside a user-gesture
+   * handler — mobile Safari and Chrome leave the context suspended otherwise, and
+   * everything scheduled against it stays silent.
+   */
+  unlock(): void
+  /** Schedules the chime to sound `secondsFromNow` from this moment. */
+  scheduleIn(secondsFromNow: number): void
+  /** Sounds the chime immediately, replacing anything already scheduled. */
+  playNow(): void
+  /**
+   * Whether the scheduled strike time has actually passed on the audio clock.
+   *
+   * A suspended context freezes `currentTime`, so this stays false when the browser
+   * swallowed a scheduled chime instead of sounding it — which is exactly what a
+   * caller needs to distinguish on returning to the foreground.
+   */
+  hasSounded(): boolean
+  /** Silences and tears down anything pending. Safe to call when nothing is scheduled. */
+  cancel(): void
+  /** Releases the AudioContext. The player is unusable afterwards. */
+  dispose(): void
+}
+
+function getAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === 'undefined') return null
+  // Neither constructor is declared on TypeScript's `Window` interface: the standard
+  // one is a bare global, and the webkit-prefixed fallback is Safari-only.
+  const candidate = window as Window & {
+    AudioContext?: AudioContextConstructor
+    webkitAudioContext?: AudioContextConstructor
+  }
+  return candidate.AudioContext ?? candidate.webkitAudioContext ?? null
+}
+
+/**
+ * Builds the oscillator graph for a single strike and starts every node at its
+ * scheduled time. Returns the oscillators so they can be stopped early on cancel.
+ */
+function buildStrike(
+  context: AudioContext,
+  destination: AudioNode,
+  startTime: number,
+  fundamentalHz: number,
+  velocity: number
+): OscillatorNode[] {
+  const oscillators: OscillatorNode[] = []
+
+  for (const partial of PARTIALS) {
+    // Doubling the prime a few cents apart produces the slow beating shimmer of a
+    // real bowl, where two sides of the rim ring at slightly different pitches.
+    const detunes = partial.ratio === 1 ? [-3.5, 3.5] : [0]
+
+    for (const detune of detunes) {
+      const oscillator = context.createOscillator()
+      oscillator.type = 'sine'
+      oscillator.frequency.setValueAtTime(fundamentalHz * partial.ratio, startTime)
+      oscillator.detune.setValueAtTime(detune, startTime)
+
+      const envelope = context.createGain()
+      const peak = (partial.gain * velocity) / detunes.length
+      envelope.gain.setValueAtTime(SILENCE, startTime)
+      envelope.gain.exponentialRampToValueAtTime(peak, startTime + ATTACK_SECONDS)
+      envelope.gain.exponentialRampToValueAtTime(SILENCE, startTime + partial.decaySeconds)
+
+      oscillator.connect(envelope)
+      envelope.connect(destination)
+
+      oscillator.start(startTime)
+      oscillator.stop(startTime + partial.decaySeconds + 0.05)
+      oscillators.push(oscillator)
+    }
+  }
+
+  return oscillators
+}
+
+export function createChimePlayer(fundamentalHz: number = DEFAULT_FUNDAMENTAL_HZ): ChimePlayer {
+  let context: AudioContext | null = null
+  let scheduled: ScheduledChime | null = null
+  let scheduledStartTime: number | null = null
+  let disposed = false
+
+  function ensureContext(): AudioContext | null {
+    if (disposed) return null
+    if (context) return context
+
+    const AudioContextCtor = getAudioContextConstructor()
+    if (!AudioContextCtor) return null
+
+    try {
+      context = new AudioContextCtor()
+    } catch (error) {
+      // No audio available (unsupported browser, blocked by policy). The timer
+      // still works visually, so degrade quietly rather than breaking the UI.
+      console.error('Completion chime unavailable:', error)
+      return null
+    }
+
+    return context
+  }
+
+  function cancel() {
+    scheduledStartTime = null
+    if (!scheduled) return
+
+    const { oscillators, master } = scheduled
+    scheduled = null
+
+    try {
+      // Duck the master gain over a few milliseconds first: stopping oscillators
+      // mid-cycle at full amplitude produces an audible click.
+      const now = master.context.currentTime
+      master.gain.cancelScheduledValues(now)
+      master.gain.setValueAtTime(master.gain.value, now)
+      master.gain.linearRampToValueAtTime(0, now + 0.02)
+
+      for (const oscillator of oscillators) {
+        oscillator.stop(now + 0.03)
+      }
+    } catch (error) {
+      console.error('Failed to cancel completion chime:', error)
+    }
+  }
+
+  function scheduleIn(secondsFromNow: number) {
+    const audioContext = ensureContext()
+    if (!audioContext) return
+
+    cancel()
+
+    try {
+      const startTime = audioContext.currentTime + Math.max(0, secondsFromNow)
+
+      const master = audioContext.createGain()
+      master.gain.setValueAtTime(MASTER_GAIN, startTime)
+      // Guarantee silence by the end of the window, however the partials decay.
+      master.gain.setValueAtTime(MASTER_GAIN, startTime + CHIME_DURATION_SECONDS - 1)
+      master.gain.linearRampToValueAtTime(0, startTime + CHIME_DURATION_SECONDS)
+
+      const lowpass = audioContext.createBiquadFilter()
+      lowpass.type = 'lowpass'
+      lowpass.frequency.setValueAtTime(LOWPASS_HZ, startTime)
+
+      master.connect(lowpass)
+      lowpass.connect(audioContext.destination)
+
+      const oscillators = STRIKES.flatMap((strike) =>
+        buildStrike(
+          audioContext,
+          master,
+          startTime + strike.delaySeconds,
+          fundamentalHz,
+          strike.velocity
+        )
+      )
+
+      scheduled = { oscillators, master }
+      scheduledStartTime = startTime
+    } catch (error) {
+      console.error('Failed to schedule completion chime:', error)
+    }
+  }
+
+  return {
+    unlock() {
+      const audioContext = ensureContext()
+      if (!audioContext) return
+      if (audioContext.state !== 'suspended') return
+
+      audioContext.resume().catch((error: unknown) => {
+        console.error('Failed to resume audio context:', error)
+      })
+    },
+
+    scheduleIn,
+
+    playNow() {
+      scheduleIn(0)
+    },
+
+    hasSounded() {
+      if (!context || scheduledStartTime === null) return false
+      return context.currentTime >= scheduledStartTime
+    },
+
+    cancel,
+
+    dispose() {
+      cancel()
+      disposed = true
+
+      const audioContext = context
+      context = null
+      if (!audioContext) return
+
+      audioContext.close().catch((error: unknown) => {
+        console.error('Failed to close audio context:', error)
+      })
+    },
+  }
+}

--- a/lib/preferences/soundPreference.ts
+++ b/lib/preferences/soundPreference.ts
@@ -1,0 +1,37 @@
+/**
+ * Whether the exercise timer sounds its completion chime, persisted locally.
+ *
+ * This is the app's first browser-persisted preference, so it also sets the
+ * convention: an `mb:`-namespaced localStorage key, a safe default when storage is
+ * unavailable, and never throwing at the call site. Storage access throws outright
+ * in Safari private mode, and reads must never run during render — they would
+ * differ between the server and client pass and trip a hydration mismatch.
+ */
+
+const SOUND_ENABLED_KEY = 'mb:timer-sound'
+
+/**
+ * Reads the stored preference. Returns true — sound on — when storage is
+ * unavailable or nothing has been stored yet.
+ */
+export function readSoundEnabled(): boolean {
+  if (typeof window === 'undefined') return true
+
+  try {
+    return window.localStorage.getItem(SOUND_ENABLED_KEY) !== 'off'
+  } catch (error) {
+    console.warn('Could not read sound preference:', error)
+    return true
+  }
+}
+
+/** Persists the preference. A failure to store is not worth interrupting the user for. */
+export function writeSoundEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(SOUND_ENABLED_KEY, enabled ? 'on' : 'off')
+  } catch (error) {
+    console.warn('Could not save sound preference:', error)
+  }
+}


### PR DESCRIPTION
## Why

The 60-second exercise timer signalled completion visually only — the ring filled, the readout hit `0:00`. During holds where you can't look at the screen, there was no way to know the interval had ended.

## What

A peaceful chime that rings out for ~10 seconds when the timer completes, plus a persisted mute toggle.

### The chime is pre-scheduled, not triggered on completion

This is the design decision worth reviewing. The countdown runs on `requestAnimationFrame`, which browsers throttle or pause when the tab is backgrounded or the phone screen locks. Firing the sound from the countdown reaching zero would sound it *late* — on refocus — in exactly the situation that motivated the feature.

Instead the chime is scheduled on the Web Audio clock at start (and re-scheduled on resume). That clock runs on its own thread, independent of rAF and the main thread, so the strike lands on time whether or not the UI is still ticking.

One gap remains: a browser can suspend the `AudioContext` outright, most likely on iOS with the screen locked, which silently swallows anything scheduled. A `visibilitychange` handler covers it — a suspended context freezes `currentTime`, so an audio clock that never reached the strike time is proof the sound never happened, and the chime plays on return to the foreground. Playing audio through a locked iPhone screen would need a media-session/service-worker setup, which is well beyond this change.

### Synthesised, not an audio file

`lib/exercises/completionChime.ts` builds a struck singing bowl with the Web Audio API: inharmonic partials (hum, prime, tierce, quint, nominal) with a decay gradient — low partials ring the full ~10s, bright upper ones fade in 1–3s — a detuned pair on the prime for the beating shimmer of a real bowl, a soft second strike, and a lowpass to take the digital edge off.

No asset to ship or cache, no dependency, no licensing, works offline. Trade-off: it's synthetic, and the exact timbre is tunable by adjusting the partial table.

### Mute toggle

Speaker icon beside Pause/Reset, persisted to `localStorage`. This is the app's first browser-persisted preference, so `lib/preferences/soundPreference.ts` sets the convention: `mb:`-namespaced key, safe default, never throws (Safari private mode throws on storage access), and read in an effect rather than during render to avoid a hydration mismatch.

No Prisma migration — preference is client-side only.

## Files

- **New** `lib/exercises/completionChime.ts` — the audio engine, pure TS, no React
- **New** `lib/preferences/soundPreference.ts` — localStorage helper
- **Modified** `app/components/ExerciseTimer.tsx` — unlock on the Start gesture, schedule/cancel across start/pause/resume/reset, mute toggle, visibility catch-up, dispose on unmount

The rAF loop, the SVG ring, the phase logic, and the `done` state machine are unchanged — the chime rides alongside them.

## Testing

`tsc --noEmit` and `next lint` are clean. Not verified in a running browser — flagged for preview testing:

- [ ] Chime sounds as the readout hits `0:00`
- [ ] It still sounds on time with the tab backgrounded from ~40s (the core requirement)
- [ ] Mute silences it and survives a reload
- [ ] Pause cancels; resume re-schedules to the correct shifted time; reset cancels
- [ ] No hydration warning in the console
- [ ] **It actually sounds peaceful** — the partial table in `completionChime.ts` is the dial to turn

## Out of scope

Server-persisted preferences, per-phase transition sounds at 20s/40s/48s, volume control, locked-screen audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
