### PR TITLE
Collapse exercise directions behind a toggle

### DIFF
--- a/app/[category]/[subcategory]/page.tsx
+++ b/app/[category]/[subcategory]/page.tsx
@@ -4,15 +4,9 @@ import type { Prisma } from '@prisma/client'
 import { getServerSession } from 'next-auth'
 import { authConfig } from '@/lib/auth'
 import Image from 'next/image'
-import { PortableText } from '@portabletext/react'
-import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react'
-import { ChevronRightIcon } from '@heroicons/react/24/outline'
-import clsx from 'clsx'
 import { CompleteExerciseButton } from '@/app/components/CompleteExerciseButton'
-import { createExerciseDescriptionComponents, isPortableTextBlocks } from '@/app/components/exerciseDescription'
+import { ExerciseDirections } from '@/app/components/ExerciseDirections'
 import { redirect } from 'next/navigation'
-
-const descriptionComponents = createExerciseDescriptionComponents('mt-2 text-sm text-slate-600')
 
 // Define valid categories and subcategories based on our schema
 const validCategories = ['conditioning', 'restorative']
@@ -121,23 +115,11 @@ export default async function ExercisesPage({ params }: PageParams) {
               )}
               <div className="p-4">
                 <h3 className="text-lg font-semibold text-slate-800">{exercise.name}</h3>
-                {isPortableTextBlocks(exercise.description) && (
-                  <Disclosure as="div" className="mt-2">
-                    {({ open }) => (
-                      <>
-                        <DisclosureButton className="flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-700">
-                          <ChevronRightIcon
-                            className={clsx('h-4 w-4 transition-transform', open && 'rotate-90')}
-                          />
-                          Directions
-                        </DisclosureButton>
-                        <DisclosurePanel>
-                          <PortableText value={exercise.description} components={descriptionComponents} />
-                        </DisclosurePanel>
-                      </>
-                    )}
-                  </Disclosure>
-                )}
+                <ExerciseDirections
+                  description={exercise.description}
+                  paragraphClassName="mt-2 text-sm text-slate-600"
+                  className="mt-2"
+                />
                 <CompleteExerciseButton
                   exerciseId={exercise.id}
                   isCompleted={exercise.isCompleted}

--- a/app/[category]/[subcategory]/page.tsx
+++ b/app/[category]/[subcategory]/page.tsx
@@ -5,6 +5,9 @@ import { getServerSession } from 'next-auth'
 import { authConfig } from '@/lib/auth'
 import Image from 'next/image'
 import { PortableText } from '@portabletext/react'
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react'
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
+import clsx from 'clsx'
 import { CompleteExerciseButton } from '@/app/components/CompleteExerciseButton'
 import { createExerciseDescriptionComponents, isPortableTextBlocks } from '@/app/components/exerciseDescription'
 import { redirect } from 'next/navigation'
@@ -119,7 +122,21 @@ export default async function ExercisesPage({ params }: PageParams) {
               <div className="p-4">
                 <h3 className="text-lg font-semibold text-slate-800">{exercise.name}</h3>
                 {isPortableTextBlocks(exercise.description) && (
-                  <PortableText value={exercise.description} components={descriptionComponents} />
+                  <Disclosure as="div" className="mt-2">
+                    {({ open }) => (
+                      <>
+                        <DisclosureButton className="flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-700">
+                          <ChevronRightIcon
+                            className={clsx('h-4 w-4 transition-transform', open && 'rotate-90')}
+                          />
+                          Directions
+                        </DisclosureButton>
+                        <DisclosurePanel>
+                          <PortableText value={exercise.description} components={descriptionComponents} />
+                        </DisclosurePanel>
+                      </>
+                    )}
+                  </Disclosure>
                 )}
                 <CompleteExerciseButton
                   exerciseId={exercise.id}

--- a/app/components/ExerciseDetailModal.tsx
+++ b/app/components/ExerciseDetailModal.tsx
@@ -1,7 +1,15 @@
 'use client'
 
-import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
-import { VideoCameraIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from '@headlessui/react'
+import { ChevronRightIcon, VideoCameraIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { PortableText } from '@portabletext/react'
 import Image from 'next/image'
 import clsx from 'clsx'
@@ -94,7 +102,21 @@ export function ExerciseDetailModal({
             </DialogTitle>
 
             {isPortableTextBlocks(exercise.description) && (
-              <PortableText value={exercise.description} components={descriptionComponents} />
+              <Disclosure key={exercise.id} as="div" className="mt-3">
+                {({ open }) => (
+                  <>
+                    <DisclosureButton className="flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-700">
+                      <ChevronRightIcon
+                        className={clsx('h-4 w-4 transition-transform', open && 'rotate-90')}
+                      />
+                      Directions
+                    </DisclosureButton>
+                    <DisclosurePanel>
+                      <PortableText value={exercise.description} components={descriptionComponents} />
+                    </DisclosurePanel>
+                  </>
+                )}
+              </Disclosure>
             )}
 
             <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/app/components/ExerciseDetailModal.tsx
+++ b/app/components/ExerciseDetailModal.tsx
@@ -1,28 +1,15 @@
 'use client'
 
-import {
-  Dialog,
-  DialogBackdrop,
-  DialogPanel,
-  DialogTitle,
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-} from '@headlessui/react'
-import { ChevronRightIcon, VideoCameraIcon, XMarkIcon } from '@heroicons/react/24/outline'
-import { PortableText } from '@portabletext/react'
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
+import { VideoCameraIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import Image from 'next/image'
 import clsx from 'clsx'
 import { CompleteExerciseButton } from './CompleteExerciseButton'
 import { LeftRightToggle } from './LeftRightToggle'
 import { ExerciseTimer } from './ExerciseTimer'
+import { ExerciseDirections } from './ExerciseDirections'
 import { getExerciseVisual } from './exerciseVisuals'
-import { createExerciseDescriptionComponents, isPortableTextBlocks } from './exerciseDescription'
 import { Exercise } from '@/app/types/exercise'
-
-const descriptionComponents = createExerciseDescriptionComponents(
-  'mt-3 text-base leading-relaxed text-slate-600'
-)
 
 interface ExerciseDetailModalProps {
   exercise: Exercise | null
@@ -101,23 +88,12 @@ export function ExerciseDetailModal({
               {exercise.name}
             </DialogTitle>
 
-            {isPortableTextBlocks(exercise.description) && (
-              <Disclosure key={exercise.id} as="div" className="mt-3">
-                {({ open }) => (
-                  <>
-                    <DisclosureButton className="flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-700">
-                      <ChevronRightIcon
-                        className={clsx('h-4 w-4 transition-transform', open && 'rotate-90')}
-                      />
-                      Directions
-                    </DisclosureButton>
-                    <DisclosurePanel>
-                      <PortableText value={exercise.description} components={descriptionComponents} />
-                    </DisclosurePanel>
-                  </>
-                )}
-              </Disclosure>
-            )}
+            <ExerciseDirections
+              key={exercise.id}
+              description={exercise.description}
+              paragraphClassName="mt-3 text-base leading-relaxed text-slate-600"
+              className="mt-3"
+            />
 
             <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
               <ExerciseTimer key={exercise.id} />

--- a/app/components/ExerciseDirections.tsx
+++ b/app/components/ExerciseDirections.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react'
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
+import { PortableText } from '@portabletext/react'
+import clsx from 'clsx'
+import { createExerciseDescriptionComponents, isPortableTextBlocks } from './exerciseDescription'
+
+interface ExerciseDirectionsProps {
+  description: unknown
+  paragraphClassName: string
+  className?: string
+}
+
+/**
+ * Rendered inside both client and server-component call sites — kept as its
+ * own 'use client' boundary so a Disclosure render-prop function never has
+ * to cross the server/client boundary as a prop from a Server Component.
+ */
+export function ExerciseDirections({ description, paragraphClassName, className }: ExerciseDirectionsProps) {
+  if (!isPortableTextBlocks(description)) return null
+
+  const components = createExerciseDescriptionComponents(paragraphClassName)
+
+  return (
+    <Disclosure as="div" className={className}>
+      {({ open }) => (
+        <>
+          <DisclosureButton className="flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-700">
+            <ChevronRightIcon className={clsx('h-4 w-4 transition-transform', open && 'rotate-90')} />
+            Directions
+          </DisclosureButton>
+          <DisclosurePanel>
+            <PortableText value={description} components={components} />
+          </DisclosurePanel>
+        </>
+      )}
+    </Disclosure>
+  )
+}


### PR DESCRIPTION
## Summary
- Exercise directions in the exercise detail modal were always rendered under the exercise title
- Wraps the directions text in a Headless UI `Disclosure`, collapsed by default, opened via a "Directions" label + chevron toggle

## Test plan
- [ ] Open an exercise with directions text from the dashboard — confirm directions are hidden by default
- [ ] Click "Directions" — confirm it expands and the chevron rotates
- [ ] Click again — confirm it collapses
- [ ] Open a different exercise — confirm it starts collapsed (not carrying over previous open state)