### PR TITLE
fix(exercises): unify the rolling completion window to a fixed 30 days

### DIFF
--- a/app/[category]/[subcategory]/page.tsx
+++ b/app/[category]/[subcategory]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
-import type { Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
+import { ROLLING_WINDOW_SQL_INTERVAL } from '@/lib/exercises/rollingWindow'
 import { getServerSession } from 'next-auth'
 import { authConfig } from '@/lib/auth'
 import Image from 'next/image'
@@ -69,7 +70,7 @@ export default async function ExercisesPage({ params }: PageParams) {
       e.description,
       e."imageUrl",
       CASE 
-        WHEN ec.id IS NOT NULL AND ec."createdAt" >= NOW() - INTERVAL '1 month' 
+        WHEN ec.id IS NOT NULL AND ec."createdAt" >= NOW() - ${Prisma.raw(ROLLING_WINDOW_SQL_INTERVAL)}
         THEN true 
         ELSE false 
       END as "isCompleted",

--- a/app/admin/students/StudentTimeline.tsx
+++ b/app/admin/students/StudentTimeline.tsx
@@ -8,6 +8,7 @@ import { ExerciseDetailModal } from '@/app/components/ExerciseDetailModal'
 import { getExerciseVisual } from '@/app/components/exerciseVisuals'
 import type { StalenessItem } from '@/lib/admin/studentInsights'
 import { Exercise } from '@/app/types/exercise'
+import { ROLLING_WINDOW_DAYS } from '@/lib/exercises/rollingWindow'
 
 interface StudentTimelineProps {
   studentId: string
@@ -22,13 +23,13 @@ function formatDaysSince(daysSince: number | null) {
 }
 
 /**
- * Matches the 30-day "this month" window used elsewhere (dashboard progress
- * ring, completion cooldown): green if done within the last month, red if
- * never done, slate for anything older.
+ * Matches the rolling window used everywhere else (dashboard progress ring,
+ * completion cooldown, suggestion eligibility — see `lib/exercises/rollingWindow.ts`):
+ * green if done within that window, red if never done, slate for anything older.
  */
 function daysSinceBadgeClass(daysSince: number | null) {
   if (daysSince === null) return 'bg-red-50 text-red-700'
-  if (daysSince <= 30) return 'bg-green-50 text-green-700'
+  if (daysSince <= ROLLING_WINDOW_DAYS) return 'bg-green-50 text-green-700'
   return 'bg-slate-100 text-slate-600'
 }
 

--- a/app/api/exercises/complete/route.ts
+++ b/app/api/exercises/complete/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authConfig } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { getRollingWindowStart } from '@/lib/exercises/rollingWindow'
 
 /**
  * POST endpoint that marks an exercise as completed for the authenticated user.
@@ -10,7 +11,7 @@ import { prisma } from '@/lib/prisma'
  * 1. Verifies the user is authenticated via their session
  * 2. Validates the exercise ID from the request body
  * 3. Looks up the user ID from their email
- * 4. Checks if the exercise was completed within the last month
+ * 4. Checks if the exercise was completed within the rolling 30-day window
  * 5. Creates an exercise completion record or updates existing one
  * 6. Handles errors like recent completions (409) and authentication issues (401)
  * 
@@ -40,22 +41,19 @@ export async function POST(request: Request) {
       return new NextResponse('User not found', { status: 401 })
     }
 
-    // Check if the exercise was completed within the last month
-    const oneMonthAgo = new Date()
-    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-
+    // Check if the exercise was completed within the rolling 30-day window
     const recentCompletion = await prisma.exerciseCompletion.findFirst({
       where: {
         userId: user.id,
         exerciseId,
         createdAt: {
-          gte: oneMonthAgo
+          gte: getRollingWindowStart()
         }
       }
     })
 
     if (recentCompletion) {
-      return new NextResponse('Exercise completed within the last month', { status: 409 })
+      return new NextResponse('Exercise completed within the last 30 days', { status: 409 })
     }
 
     // Delete any older completion and create a new one

--- a/lib/exercises/completeExercise.ts
+++ b/lib/exercises/completeExercise.ts
@@ -1,14 +1,13 @@
+import { getRollingWindowStart } from '@/lib/exercises/rollingWindow'
+
 /**
- * Whether an exercise was completed within the last month — the app's
- * cooldown window before an exercise can be marked complete again.
+ * Whether an exercise was completed within the rolling 30-day window — the
+ * app's cooldown before an exercise can be marked complete again.
  */
 export function isRecentlyCompleted(isCompleted: boolean, completedAt: Date | null | undefined): boolean {
   if (!isCompleted || !completedAt) return false
 
-  const oneMonthAgo = new Date()
-  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-
-  return new Date(completedAt) >= oneMonthAgo
+  return new Date(completedAt) >= getRollingWindowStart()
 }
 
 /**
@@ -16,7 +15,7 @@ export function isRecentlyCompleted(isCompleted: boolean, completedAt: Date | nu
  * user, or POST /api/admin/students/:studentId/complete on behalf of a
  * student when studentId is passed (instructor use from /admin/students —
  * no cooldown there). Throws if the exercise was completed within the last
- * month (409, self-serve only) or the request otherwise fails.
+ * 30 days (409, self-serve only) or the request otherwise fails.
  */
 export async function completeExercise(exerciseId: string, studentId?: string): Promise<void> {
   const url = studentId ? `/api/admin/students/${studentId}/complete` : '/api/exercises/complete'
@@ -30,7 +29,7 @@ export async function completeExercise(exerciseId: string, studentId?: string): 
 
   if (!response.ok) {
     if (response.status === 409) {
-      throw new Error('Exercise completed within the last month')
+      throw new Error('Exercise completed within the last 30 days')
     }
     throw new Error('Failed to complete exercise')
   }

--- a/lib/exercises/progress.ts
+++ b/lib/exercises/progress.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { REQUIRED_CATEGORIES } from '@/lib/exercises/categories'
+import { getRollingWindowStart } from '@/lib/exercises/rollingWindow'
 
 export type CatalogProgress = {
   /** Count of distinct required-plan exercises this user has completed within the last 30 days. */
@@ -29,14 +30,11 @@ export type CatalogProgress = {
  * student and be useless as a monthly goal.
  */
 export async function getCatalogProgress(userId: string): Promise<CatalogProgress> {
-  const thirtyDaysAgo = new Date()
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
-
   const [completedCount, totalCount] = await Promise.all([
     prisma.exerciseCompletion.count({
       where: {
         userId,
-        createdAt: { gte: thirtyDaysAgo },
+        createdAt: { gte: getRollingWindowStart() },
         exercise: { category: { in: [...REQUIRED_CATEGORIES] } },
       },
     }),

--- a/lib/exercises/rollingWindow.ts
+++ b/lib/exercises/rollingWindow.ts
@@ -1,0 +1,31 @@
+/**
+ * Single source of truth for the rolling window used everywhere "this
+ * month" is computed for exercise completions: the re-completion cooldown,
+ * the dashboard progress ring, daily suggestion eligibility, and the
+ * instructor staleness view.
+ *
+ * Previously this was duplicated as both a fixed 30-day window (progress
+ * ring, staleness view) and a calendar "1 month" window (completion
+ * cooldown, suggestion eligibility) at different call sites. A calendar
+ * month is almost always longer than 30 days (28-31, depending on the
+ * month), so an exercise could fall out of the fixed-30-day "still counts
+ * as done" window before the calendar-month "eligible to redo" window
+ * opened — a gap where it vanished from both the progress count and the
+ * suggestions list at once. See CHA-46.
+ */
+export const ROLLING_WINDOW_DAYS = 30
+
+/** `now - ROLLING_WINDOW_DAYS`, for Prisma `gte`/`lt` filters on `createdAt`. */
+export function getRollingWindowStart(now: Date = new Date()): Date {
+  const start = new Date(now)
+  start.setDate(start.getDate() - ROLLING_WINDOW_DAYS)
+  return start
+}
+
+/**
+ * Raw SQL interval text for `$queryRaw` templates. Wrap with `Prisma.raw(...)`
+ * at the call site (kept as a plain string here, with no Prisma import, so
+ * this file stays safe to import from client components via
+ * `lib/exercises/completeExercise.ts`).
+ */
+export const ROLLING_WINDOW_SQL_INTERVAL = `INTERVAL '${ROLLING_WINDOW_DAYS} days'`

--- a/lib/sessions/suggestions.ts
+++ b/lib/sessions/suggestions.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@prisma/client'
 import type { ExerciseCompletion, Exercise as PrismaExercise } from '@prisma/client'
 import { getCatalogProgress } from '@/lib/exercises/progress'
 import { BONUS_CATEGORIES, REQUIRED_CATEGORIES } from '@/lib/exercises/categories'
+import { ROLLING_WINDOW_SQL_INTERVAL } from '@/lib/exercises/rollingWindow'
 
 interface SuggestedExercise {
   id: string
@@ -31,7 +32,7 @@ export type DashboardDailySuggestionsPayload = {
 /**
  * Returns one un-completed exercise per category/subcategory group for the
  * given user, limited to `categories` and excluding anything completed in the
- * last month. Within each group, exercises that have gone longest without
+ * last 30 days. Within each group, exercises that have gone longest without
  * being completed are
  * prioritized (never-completed exercises rank above ones the user is merely
  * eligible for again after the cooldown), with a random tiebreak among
@@ -78,7 +79,7 @@ export async function getSuggestedExercises(
       FROM exercises e
       LEFT JOIN LastCompletion lc ON lc."exerciseId" = e.id
       WHERE e.category IN (${Prisma.join(categories)})
-        AND (lc.last_completed_at IS NULL OR lc.last_completed_at < NOW() - INTERVAL '1 month')
+        AND (lc.last_completed_at IS NULL OR lc.last_completed_at < NOW() - ${Prisma.raw(ROLLING_WINDOW_SQL_INTERVAL)})
         AND NOT EXISTS (
           SELECT 1 FROM CompletedTodaySlots cts
           WHERE cts.category = e.category
@@ -101,7 +102,7 @@ export async function getSuggestedExercises(
 
 /**
  * Returns all exercises the user is eligible for today (not completed
- * in the last month), in random order.
+ * in the last 30 days), in random order.
  */
 export async function getEligibleExercises(userId: string): Promise<SuggestedExercise[]> {
   return prisma.$queryRaw<SuggestedExercise[]>`
@@ -119,7 +120,7 @@ export async function getEligibleExercises(userId: string): Promise<SuggestedExe
       FROM exercise_completions ec
       WHERE e.id = ec."exerciseId"
       AND ec."userId" = ${userId}
-      AND ec."createdAt" >= NOW() - INTERVAL '1 month'
+      AND ec."createdAt" >= NOW() - ${Prisma.raw(ROLLING_WINDOW_SQL_INTERVAL)}
     )
     ORDER BY random();
   `
@@ -129,7 +130,7 @@ export async function getEligibleExercises(userId: string): Promise<SuggestedExe
  * Loads dashboard daily-suggestion data in one round trip where possible.
  *
  * `requiredPlanCompleteInRollingWindow` is true when the user has a completion
- * dated within the rolling one-month window for every Conditioning and
+ * dated within the rolling 30-day window for every Conditioning and
  * Restorative exercise (same rule as category pages and
  * `/api/exercises/complete`) — this is intentionally derived from
  * `getCatalogProgress`, not from `suggestedExercises` being empty, since


### PR DESCRIPTION
## Summary

- The exercise completion cooldown and the daily-suggestion eligibility query used calendar **"1 month"** arithmetic (`Date.setMonth(-1)` / Postgres `INTERVAL '1 month'`), while the dashboard progress ring and instructor staleness view used a **fixed 30 days**.
- A calendar month is almost always longer than 30 days, so an exercise could fall out of the "still counts as done" window before the "eligible to redo" window opened — invisible to the progress ring *and* the suggestion engine at the same time. That's exactly what CHA-46 reported: ring showed 7 exercises still needed, Daily Suggestions showed nothing to do.
- Introduces `lib/exercises/rollingWindow.ts` as the single source of truth (`ROLLING_WINDOW_DAYS = 30`) and points every call site at it — including the category/subcategory listing page and the client-side cooldown check, which had the same duplication.

Fixes [CHA-46](https://linear.app/charlie-virgo/issue/CHA-46).

## Test plan

- [x] `npx tsc --noEmit` — clean (2 pre-existing, unrelated image-import errors on files this PR doesn't touch)
- [x] `npx next lint` — clean
- [x] Read-only verification script against production data (Charlie's account): confirmed every exercise the progress ring counts as "still needed" is now also eligible for suggestion — no dead zone. Script was scratch-only, not included in this PR.
- [ ] Manual click-through on a preview deploy: complete an exercise, confirm dashboard ring and Daily Suggestions agree at every point in the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)